### PR TITLE
Add fish shell setup to `env` command and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@
   ```bash
   eval `fnm env`
   ```
+  
+  If you are using [fish shell](https://fishshell.com/), add this line to your `config.fish` file:
+  
+  ```fish
+  set PATH $HOME/.fnm/current/bin $PATH
+  ```
 
 ## Future Plans
 - [ ] Add a simpler way of installing it (`curl | bash`?)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
   If you are using [fish shell](https://fishshell.com/), add this line to your `config.fish` file:
   
   ```fish
-  set PATH $HOME/.fnm/current/bin $PATH
+  eval (fnm env --fish)
   ```
 
 ## Future Plans

--- a/executable/Env.re
+++ b/executable/Env.re
@@ -1,9 +1,15 @@
 open Fnm;
 
-let run = () => {
-  Console.log(
-    Printf.sprintf("export PATH=%s/bin:$PATH", Directories.currentVersion),
-  );
+let run = isFishShell => {
+  if (isFishShell) {
+    Console.log(
+      Printf.sprintf("set PATH %s/bin $PATH", Directories.currentVersion),
+    );
+  } else {
+    Console.log(
+      Printf.sprintf("export PATH=%s/bin:$PATH", Directories.currentVersion),
+    );
+  }
 
   Lwt.return();
 };

--- a/executable/FnmApp.re
+++ b/executable/FnmApp.re
@@ -5,7 +5,7 @@ module Commands = {
   let listRemote = () => Lwt_main.run(ListRemote.run());
   let listLocal = () => Lwt_main.run(ListLocal.run());
   let install = version => Lwt_main.run(Install.run(~version));
-  let env = () => Lwt_main.run(Env.run());
+  let env = isFishShell => Lwt_main.run(Env.run(isFishShell));
 };
 
 open Cmdliner;
@@ -88,8 +88,16 @@ let env = {
   let doc = "Show env configurations";
   let sdocs = Manpage.s_common_options;
   let man = help_secs;
+
+  let isFishShell = {
+    let doc = "Output an env configuration for fish shell.";
+    Arg.(
+      value & flag & info(["fish"], ~doc)
+    );
+  };
+
   (
-    Term.(const(Commands.env) $ const()),
+    Term.(const(Commands.env) $ isFishShell),
     Term.info("env", ~version, ~doc, ~exits=Term.default_exits, ~man, ~sdocs),
   );
 };


### PR DESCRIPTION
I've been testing fnm in fish shell, and it works great! Just this one setup step is needed to get it working.

UPDATE: introduced a `--fish` flag to the env command, so fish users can add this line to their `config.fish` to set up fnm:

```fish
eval (fnm env --fish)
```

---

PREVIOUS DESCRIPTION:

The drawback of this is that the `$HOME/.fnm/current/bin` implementation detail is not hidden behind the `fnm env` command.

Another possible solution is to modify the `env` command to output the fish setup commands. e.g.

```
$ fnm env --fish
set PATH $HOME/.fnm/current/bin $PATH
```

Then the README can say `eval (fnm env --fish)`. I'm willing to contribute this; just need some time to get my environment set up and learn a bit of ReasonML 😄 