### PR TITLE
Use xz files instead of gz

### DIFF
--- a/executable/Install.re
+++ b/executable/Install.re
@@ -44,7 +44,10 @@ let main = (~version as versionName) => {
   let%lwt filepath =
     Versions.getFileToDownload(~version=versionName, ~os, ~arch);
   let tarDestination =
-    Filename.concat(Directories.downloads, versionName ++ ".tar.gz");
+    Filename.concat(
+      Directories.downloads,
+      versionName ++ Versions.Remote.downloadFileSuffix,
+    );
 
   Console.log(
     <Pastel>

--- a/library/Versions.re
+++ b/library/Versions.re
@@ -43,7 +43,7 @@ module Remote = {
     |> List.map(Soup.attribute("href"))
     |> Core.List.filter_map(~f=x => x);
 
-  let downloadFileSuffix = ".tar.gz";
+  let downloadFileSuffix = ".tar.xz";
 
   let getVersionFromFilename = filename => {
     let strings = filename |> String.split_on_char('-');


### PR DESCRIPTION
`.tar.xz` files are usually smaller than `.tar.gz`, so it'll be faster to download those.

Fixes #7