### PR TITLE
skip installation if the version is already installed

### DIFF
--- a/executable/Install.re
+++ b/executable/Install.re
@@ -27,7 +27,7 @@ let main = (~version as versionName) => {
     };
 
   let versionName = Versions.format(versionName);
-  let%lwt _ = Versions.isAlreadyInstalled(versionName);
+  let%lwt _ = Versions.throwIfInstalled(versionName);
 
   Console.log(
     <Pastel>
@@ -99,15 +99,6 @@ let run = (~version) =>
         "Version "
         <Pastel color=Pastel.Cyan> version </Pastel>
         " not found!"
-      </Pastel>,
-    )
-    |> Lwt.return
-  | Versions.Already_installed(version) =>
-    Console.log(
-      <Pastel>
-        "Version "
-        <Pastel color=Pastel.Cyan> version </Pastel>
-        " is already installed"
       </Pastel>,
     )
     |> Lwt.return

--- a/executable/Install.re
+++ b/executable/Install.re
@@ -27,6 +27,7 @@ let main = (~version as versionName) => {
     };
 
   let versionName = Versions.format(versionName);
+  let%lwt _ = Versions.isAlreadyInstalled(versionName);
 
   Console.log(
     <Pastel>
@@ -98,6 +99,15 @@ let run = (~version) =>
         "Version "
         <Pastel color=Pastel.Cyan> version </Pastel>
         " not found!"
+      </Pastel>,
+    )
+    |> Lwt.return
+  | Versions.Already_installed(version) =>
+    Console.log(
+      <Pastel>
+        "Version "
+        <Pastel color=Pastel.Cyan> version </Pastel>
+        " is already installed"
       </Pastel>,
     )
     |> Lwt.return

--- a/library/Versions.re
+++ b/library/Versions.re
@@ -149,10 +149,10 @@ let getRemoteVersions = () => {
 
 let throwIfInstalled = versionName => {
   switch (getInstalledVersions()) {
+  | Error(_) => Lwt.return()
   | Ok(x) =>
     Array.to_list(x)
     |> List.exists(x => Local.(x.name == versionName))
     |> (x => x ? Lwt.fail(Already_installed(versionName)) : Lwt.return())
-  | Error(_) => Lwt.return()
   };
 };

--- a/library/Versions.re
+++ b/library/Versions.re
@@ -152,8 +152,7 @@ let throwIfInstalled = versionName => {
   |> Result.fold(
        _ => Lwt.return(),
        xs =>
-         Array.to_list(xs)
-         |> List.exists(x => Local.(x.name == versionName))
+         Array.exists(x => Local.(x.name == versionName), xs)
          |> (
            x => x ? Lwt.fail(Already_installed(versionName)) : Lwt.return()
          ),

--- a/library/Versions.re
+++ b/library/Versions.re
@@ -148,18 +148,11 @@ let getRemoteVersions = () => {
 };
 
 let throwIfInstalled = versionName => {
-  switch(getInstalledVersions()) {
-  | Ok(x) => {
+  switch (getInstalledVersions()) {
+  | Ok(x) =>
     Array.to_list(x)
-    |> List.exists(x => {
-      open Local;
-      x.name == versionName;
-    })
-    |> x => switch x {
-    | true => Lwt.fail(Already_installed(versionName));
-    | false => Lwt.return();
-    };
-  };
-  | Error(_) => Lwt.return();
+    |> List.exists(x => Local.(x.name == versionName))
+    |> (x => x ? Lwt.fail(Already_installed(versionName)) : Lwt.return())
+  | Error(_) => Lwt.return()
   };
 };

--- a/library/Versions.re
+++ b/library/Versions.re
@@ -59,8 +59,7 @@ let format = version => {
     | exception _ => version
     };
 
-  let ansiCharRegex = Str.regexp({|\\027\[[0-9]+m|});
-  Str.global_replace(ansiCharRegex, "", String.escaped(version));
+  version;
 };
 
 let endsWith = (~suffix, str) => {

--- a/library/Versions.re
+++ b/library/Versions.re
@@ -58,7 +58,8 @@ let format = version => {
     | exception _ => version
     };
 
-  version;
+  let ansiCharRegex = Str.regexp({|\\027\[[0-9]+m|});
+  Str.global_replace(ansiCharRegex, "", String.escaped(version));
 };
 
 let endsWith = (~suffix, str) => {

--- a/library/Versions.re
+++ b/library/Versions.re
@@ -148,11 +148,14 @@ let getRemoteVersions = () => {
 };
 
 let throwIfInstalled = versionName => {
-  switch (getInstalledVersions()) {
-  | Error(_) => Lwt.return()
-  | Ok(x) =>
-    Array.to_list(x)
-    |> List.exists(x => Local.(x.name == versionName))
-    |> (x => x ? Lwt.fail(Already_installed(versionName)) : Lwt.return())
-  };
+  getInstalledVersions()
+  |> Result.fold(
+       _ => Lwt.return(),
+       xs =>
+         Array.to_list(xs)
+         |> List.exists(x => Local.(x.name == versionName))
+         |> (
+           x => x ? Lwt.fail(Already_installed(versionName)) : Lwt.return()
+         ),
+     );
 };

--- a/library/Versions.re
+++ b/library/Versions.re
@@ -147,7 +147,7 @@ let getRemoteVersions = () => {
   |> Lwt.return;
 };
 
-let isAlreadyInstalled = versionName => {
+let throwIfInstalled = versionName => {
   switch(getInstalledVersions()) {
   | Ok(x) => {
     Array.to_list(x)

--- a/library/Versions.re
+++ b/library/Versions.re
@@ -8,6 +8,7 @@ module Local = {
 };
 
 exception Version_not_found(string);
+exception Already_installed(string);
 
 module Remote = {
   type t = {
@@ -145,4 +146,21 @@ let getRemoteVersions = () => {
        }
      )
   |> Lwt.return;
+};
+
+let isAlreadyInstalled = versionName => {
+  switch(getInstalledVersions()) {
+  | Ok(x) => {
+    Array.to_list(x)
+    |> List.exists(x => {
+      open Local;
+      x.name == versionName;
+    })
+    |> x => switch x {
+    | true => Lwt.fail(Already_installed(versionName));
+    | false => Lwt.return();
+    };
+  };
+  | Error(_) => Lwt.return();
+  };
 };


### PR DESCRIPTION
~1. When install specify version from `fnm ls-remote`, the version which has been installed contains ANSI codes and `fnm install` raise internal error.~

i reverted it.

```
$ fnm install $(fnm ls-remote | grep -E "\* v[0-9]?[0,2,4,6,8]" | tail -n 1 | sed -r -e "s/\* //g")

Looking for node v10.15.1 for linux x64
fnm: internal error, uncaught exception:
     (Failure hd)
     Raised at file "pervasives.ml", line 32, characters 17-33
     Called from file "list.ml" (inlined), line 27, characters 10-23
     Called from file "library/Http.re", line 36, characters 25-41
     Called from file "library/Http.re", line 43, characters 2-27
     Called from file "src/core/lwt.ml", line 1929, characters 23-26
     Re-raised at file "library/Http.re", line 41, characters 2-133
     Re-raised at file "library/Versions.re", line 80, characters 2-580
     Re-raised at file "executable/Install.re", line 45, characters 2-942
     Re-raised at file "src/core/lwt.ml", line 2987, characters 20-29
     Called from file "src/unix/lwt_main.ml", line 26, characters 8-18
     Called from file "cmdliner_term.ml", line 25, characters 19-24
     Called from file "cmdliner.ml", line 116, characters 32-39
```

2. skip to install the version which has been already installed