### PR TITLE
Parameterize the install script for relative install of fnm

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -30,6 +30,10 @@ parse_args() {
 	  SKIP_SHELL="true"
 	  shift # past argument
 	  ;;
+	  *)
+	  echo "Unrecognized argument $key"
+	  exit 1
+	  ;;
   esac
   done
 }

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -12,6 +12,31 @@ else
   exit 1
 fi
 
+INSTALL_DIR="$HOME/.fnm"
+
+# Parse Flags
+parse_args() {
+  while [[ $# -gt 0 ]]
+  do
+  key="$1"
+
+  case $key in
+	  -d|--install-dir)
+	  INSTALL_DIR="$2"
+	  shift # past argument
+	  shift # past value
+	  ;;
+	  -s|--skip-shell)
+	  SKIP_SHELL="true"
+	  shift # past argument
+	  ;;
+  esac
+  done
+}
+
+parse_args "$@"
+
+
 get_latest_release() {
   # Taken from https://gist.github.com/lukechilds/a83e1d7127b78fef38c2914c4ececc3c
   curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
@@ -26,11 +51,11 @@ download_fnm() {
 
   echo "Downloading $URL..."
 
-  mkdir -p $HOME/.fnm &> /dev/null
+  mkdir -p $INSTALL_DIR &> /dev/null
   curl --progress-bar -L $URL -o $DOWNLOAD_DIR/$FILENAME.zip
   unzip -q $DOWNLOAD_DIR/$FILENAME.zip -d $DOWNLOAD_DIR
-  mv $DOWNLOAD_DIR/$FILENAME/fnm $HOME/.fnm/fnm
-  chmod u+x $HOME/.fnm/fnm
+  mv $DOWNLOAD_DIR/$FILENAME/fnm $INSTALL_DIR/fnm
+  chmod u+x $INSTALL_DIR/fnm
 }
 
 check_dependencies() {
@@ -112,4 +137,6 @@ setup_shell() {
 
 check_dependencies
 download_fnm
-setup_shell
+if [ "$SKIP_SHELL" != "true" ]; then 
+  setup_shell
+fi

--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ For `bash`, `zsh` and `fish` shells, there's an [automatic installation script](
 curl https://raw.githubusercontent.com/Schniz/fnm/master/.ci/install.sh | bash
 ```
 
+#### Parameters
+
+`--install-dir`
+
+Set a custom directory for fnm to be installed. The default is `$HOME/.fnm`.
+
+`--skip-shell`
+
+Skip appending shell specific loader to shell config file, based on the current user shell, defined in `$SHELL`. e.g. for Bash, `$HOME/.bashrc`. `$HOME/.zshrc` for Zsh. For Fish - `$HOME/.config/fish/config.fish`
+
+Example: 
+```bash
+curl https://raw.githubusercontent.com/Schniz/fnm/master/.ci/install.sh | bash --install-dir "./.fnm" --skip-shell
+```
+
 ### Manually
 
 - Download the [latest release binary](https://github.com/Schniz/fnm/releases) for your system


### PR DESCRIPTION
What are your thoughts on parameterizing the install script for local install? I know this seems weird but it means that I don't have to rely on developers having any tools already installed except bash and some way to edit the files. Here is an actual example script setup I would use.

Here is an example local install script `installLocal.sh`
```bash
#!/usr/bin/env bash

DESIRED_NODE_VERSION=v$(cat package.json | grep -Ei "\"node\"" | grep -Eoi "[0-9]+\.[0-9]+\.[0-9]+") 

export FNM_DIR="$(pwd)/.fnm"
if [ ! -d "$FNM_DIR" ]; then
    curl 'https://raw.githubusercontent.com/Schniz/fnm/master/.ci/install.sh' | INSTALL_DIR=`pwd` bash
fi

set -e

NODE_DIR="$FNM_DIR/node-versions/$DESIRED_NODE_VERSION/installation/bin"
export PATH=$FNM_DIR:$NODE_DIR:$PATH

#TODO: support fish
eval `fnm env --multi`

if [ ! -f "$NODE_DIR/node" ]; then
    fnm install $DESIRED_NODE_VERSION
fi

sumOfPackageJson() {
    cat package.json | md5sum | cut -d' ' -f1
}

if [ ! -f ".packageRevision" ] || [ "$(cat .packageRevision)" != "$(sumOfPackageJson)" ]; then
    sumOfPackageJson > .packageRevision
    npm install
fi
```

then in script called `nodew`

```bash
#!/usr/bin/env bash
cd "$( dirname "${BASH_SOURCE[0]}" )"
source ./installLocal.sh
node "$@"
```

and `npmw`
```bash
#!/usr/bin/env bash
cd "$( dirname "${BASH_SOURCE[0]}" )"
source ./installLocal.sh
npm "$@"
```

and for completeness sake I usually go one step further and do an `appw`
```bash
#!/usr/bin/env bash
cd "$( dirname "${BASH_SOURCE[0]}" )"
source ./installLocal.sh
node ./app/index.js "$@"
```