### PR TITLE
Infer complete semver (`vX.X.X`) out of partial input (`vX`/`vX.X`).

### DIFF
--- a/executable/Install.re
+++ b/executable/Install.re
@@ -42,8 +42,11 @@ let main = (~version as versionName) => {
     </Pastel>,
   );
 
-  let%lwt filepath =
+  let%lwt (versionName, filepath) =
     Versions.getFileToDownload(~version=versionName, ~os, ~arch);
+
+  let%lwt _ = Versions.throwIfInstalled(versionName);
+
   let tarDestination =
     Filename.concat(
       Directories.downloads,

--- a/executable/Use.re
+++ b/executable/Use.re
@@ -21,6 +21,12 @@ let switchVersion = (~version, ~quiet) => {
     | Alias(alias) => Versions.Aliases.toDirectory(alias) |> Lwt.return
     };
 
+  let versionName =
+    switch (parsedVersion) {
+    | Local(v) => v
+    | Alias(v) => v
+    };
+
   let destination = Filename.concat(versionPath, "installation");
   let source = Directories.currentVersion;
 
@@ -45,7 +51,10 @@ let switchVersion = (~version, ~quiet) => {
     };
 
   log(
-    <Pastel> "Using " <Pastel color=Pastel.Cyan> version </Pastel> </Pastel>,
+    <Pastel>
+      "Using "
+      <Pastel color=Pastel.Cyan> versionName </Pastel>
+    </Pastel>,
   );
 
   Lwt.return();

--- a/feature_tests/partial_semver/run.sh
+++ b/feature_tests/partial_semver/run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+eval `fnm env --multi`
+
+fnm install 6 # no new versions would be issued for this unsupported version
+fnm install 8.11.3
+
+fnm use 6
+if [ "$(node -v)" != "v6.16.0" ]; then
+  echo "Node version mismatch: $(node -v). Expected: v6.16.0"
+fi
+
+fnm use 8
+if [ "$(node -v)" != "v8.11.3" ]; then
+  echo "Node version mismatch: $(node -v). Expected: v8.11.3"
+fi


### PR DESCRIPTION
Resolves #35

Adds the support of supplying a partial semver (MAJOR/MAJOR.MINOR) and infer the rest:

```bash
fnm install 6 # installs the latest Node 6 version
fnm use 6 # uses the latest Node 6 version installed
```