### PR TITLE
Correct status code on `install` failures

### DIFF
--- a/executable/Install.re
+++ b/executable/Install.re
@@ -94,8 +94,8 @@ let run = (~version) =>
         "  Architecture: "
         <Pastel color=Pastel.Cyan> {System.NodeArch.toString(arch)} </Pastel>
       </Pastel>,
-    )
-    |> Lwt.return
+    );
+    exit(1);
   | Versions.Already_installed(version) =>
     Console.log(
       <Pastel>
@@ -112,6 +112,6 @@ let run = (~version) =>
         <Pastel color=Pastel.Cyan> version </Pastel>
         " not found!"
       </Pastel>,
-    )
-    |> Lwt.return
+    );
+    exit(1);
   };


### PR DESCRIPTION
Fixes #53 

Change the status code to 1 for cases when the version was not found or there is no download available.