### PR TITLE
Adding check for OSX during writing for bash shell

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -87,7 +87,11 @@ setup_shell() {
     echo 'eval (fnm env --multi --fish)' >> $CONF_FILE
 
   elif [ "$CURRENT_SHELL" == "bash" ]; then
-    CONF_FILE=$HOME/.bashrc
+    if [ "$OS" == "Darwin" ]; then
+      CONF_FILE=$HOME/.profile
+    else
+      CONF_FILE=$HOME/.bashrc
+    fi
     echo "Installing for Bash. Appending the following to $CONF_FILE:"
     echo ""
     echo '  # fnm'


### PR DESCRIPTION
OS X users experience issues due to .bashrc not being
sourced on start up.

Fixes #40