### PR TITLE
Fix a bug where `fnm env --multi` didn't used the default alias

### DIFF
--- a/executable/Env.re
+++ b/executable/Env.re
@@ -20,11 +20,7 @@ let rec makeTemporarySymlink = () => {
     let%lwt suggestedName = makeTemporarySymlink();
     Lwt.return(suggestedName);
   } else {
-    let%lwt _ =
-      Lwt_unix.symlink(
-        Filename.concat(Directories.defaultVersion, "installation"),
-        suggestedName,
-      );
+    let%lwt _ = Lwt_unix.symlink(Directories.defaultVersion, suggestedName);
     Lwt.return(suggestedName);
   };
 };


### PR DESCRIPTION
The default link on `fnm env --multi` was to `aliases/default/installation`, but `/installation` isn't needed