### PR TITLE
Guard from more non-existent directories errors

### DIFF
--- a/library/Fs.re
+++ b/library/Fs.re
@@ -35,4 +35,10 @@ let writeFile = (path, contents) => {
   Lwt.return();
 };
 
+let exists = path => {
+  try%lwt (Lwt_unix.file_exists(path)) {
+  | Unix.Unix_error(_, _, _) => Lwt.return(false)
+  };
+};
+
 let realpath = Filename.realpath;


### PR DESCRIPTION
Catch more Unix 125 errors, Fixes #75:

> I believe the error happens when you have zero node installations handled by fnm. Try removing those versions you have (or moving the `~/.fnm/node-versions/` folder somewhere else for that matter) and you should be able to reproduce the problem.

Thanks @julen for the report!