### PR TITLE
fix: remove unmatched quote written in the fish config file

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -115,7 +115,7 @@ setup_shell() {
     echo '' >> $CONF_FILE
     echo '# fnm' >> $CONF_FILE
     echo 'set PATH $HOME/.fnm $PATH' >> $CONF_FILE
-    echo 'fnm env --multi | source"' >> $CONF_FILE
+    echo 'fnm env --multi | source' >> $CONF_FILE
 
   elif [ "$CURRENT_SHELL" == "bash" ]; then
     if [ "$OS" == "Darwin" ]; then


### PR DESCRIPTION
There's an unmatched double quote written in the fish config file by the installer that breaks sourcing that said config file.