### PR TITLE
Fix `fnm env` for fish shell.

### DIFF
--- a/executable/Env.re
+++ b/executable/Env.re
@@ -104,12 +104,12 @@ let run = (~forceShell, ~multishell, ~nodeDistMirror, ~fnmDir, ~useOnCd) => {
     )
     |> Console.log;
   | Fish =>
-    Printf.sprintf("set PATH %s/bin $PATH;", path) |> Console.log;
-    Printf.sprintf("set %s %s;", Config.FNM_MULTISHELL_PATH.name, path)
+    Printf.sprintf("set -gx PATH %s/bin $PATH;", path) |> Console.log;
+    Printf.sprintf("set -gx %s %s;", Config.FNM_MULTISHELL_PATH.name, path)
     |> Console.log;
-    Printf.sprintf("set %s %s;", Config.FNM_DIR.name, fnmDir) |> Console.log;
+    Printf.sprintf("set -gx %s %s;", Config.FNM_DIR.name, fnmDir) |> Console.log;
     Printf.sprintf(
-      "set %s %s",
+      "set -gx %s %s",
       Config.FNM_NODE_DIST_MIRROR.name,
       nodeDistMirror,
     )


### PR DESCRIPTION
After running `fnm env --multi | source` in fish I noticed that running `fnm use` still relinks `~/.fnm/current` rather then the folder in tmp that it is supposed to relink in the --multi case.

I realised that `fnm` cannot see the `FNM_...` variables as they are not exported (using -x) when they get set.

> ~/> set --show FNM_DIR
> $FNM_DIR: not set in local scope
> $FNM_DIR: set in global scope, unexported, with 1 elements
> $FNM_DIR[1]: length=17 value=|/Users/harry/.fnm|
> $FNM_DIR: not set in universal scope

So I added `-gx` to the `set` commands for fish so that the variables can be picked up by later runs of `fnm`. There are cases where the setup current code already works however it doesn't when the `FNM_...` variables haven't been exported globally before.
