### PR TITLE
Shorten installation script url

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 For `bash`, `zsh` and `fish` shells, there's an [automatic installation script](./.ci/install.sh):
 
 ```bash
-curl https://raw.githubusercontent.com/Schniz/fnm/master/.ci/install.sh | bash
+curl -fsSL https://github.com/Schniz/fnm/raw/master/.ci/install.sh | bash
 ```
 
 #### Parameters
@@ -41,7 +41,7 @@ Skip appending shell specific loader to shell config file, based on the current 
 Example:
 
 ```bash
-curl https://raw.githubusercontent.com/Schniz/fnm/master/.ci/install.sh | bash -s -- --install-dir "./.fnm" --skip-shell
+curl -fsSL https://github.com/Schniz/fnm/raw/master/.ci/install.sh | bash -s -- --install-dir "./.fnm" --skip-shell
 ```
 
 ### Manually


### PR DESCRIPTION
Github supports redirecting from:
```sh
https://github.com/<owner>/<repo>/raw/<branch>/<path>
# installation script url
https://github.com/Schniz/fnm/raw/master/.ci/install.sh
```
to:
```sh
https://raw.githubusercontent.com/<owner>/<repo>/<branch>/<path>
# installation script url
https://raw.githubusercontent.com/Schniz/fnm/master/.ci/install.sh
```
Obviously, main motivation for the proposed change is _user-friendliness_ of such url in terms of length and being able to guess/construct it. However that requires adding `-L` flag to `curl` invocation in order to track redirects. 
That led me too add 3 more (`-fsS`) that are lovely explained [here](https://explainshell.com/explain?cmd=curl+-fsSL+https://example.com) and being used by [`oh-my-zsh`](https://github.com/robbyrussell/oh-my-zsh#basic-installation) and [`brew` (homepage source)](https://github.com/Homebrew/brew.sh/blob/52a63e44b779f13497162b010f5730e78a7d7abd/_layouts/index.html#L11) also.

I'm eager to hear your thoughts 👂 and ofc thank you for your awesome tool ❤️ 