### PR TITLE
fix EACCES error when installing an already downloaded version

### DIFF
--- a/library/Fs.re
+++ b/library/Fs.re
@@ -26,12 +26,11 @@ let readdir = dir => {
 };
 
 let writeFile = (path, contents) => {
-  let%lwt x = Lwt_unix.openfile(path, [Unix.O_RDWR, Unix.O_CREAT], 777);
-  let%lwt _ =
-    Lwt.finalize(
-      () => Lwt_unix.write_string(x, contents, 0, String.length(contents)),
-      () => Lwt_unix.close(x),
-    );
+  let%lwt targetFile = Lwt_io.open_file(~mode=Lwt_io.Output, path);
+
+  let%lwt () = Lwt_io.write(targetFile, contents);
+  let%lwt () = Lwt_io.close(targetFile);
+
   Lwt.return();
 };
 


### PR DESCRIPTION
This should fix an issue that arises we delete a version (by deleting the folder within the `node-versions` folder but keeping the downloaded `.tar.xz` file) and trying to reinstall it.

This was happening due to some access permission on the `.tar.xz` file. I tried to use other permissions when creating the file:
``` reason
Lwt_unix.openfile(path, [Unix.O_RDWR, Unix.O_CREAT], 777)
```

But didn't really understand it 😝 I finally ended up by using `Lwt_io` instead of `Lwt_unix` like [here](https://github.com/fastpack/fastpack/blob/master/FastpackUtil/FS.re#L81) and it seems to fix the issue 🎉 

