### PR TITLE
Fix missing aliases due to newer `realpath`

### DIFF
--- a/executable/Use.re
+++ b/executable/Use.re
@@ -29,7 +29,6 @@ let switchVersion = (~version, ~quiet) => {
     | System => "system"
     };
 
-  let destination = Filename.concat(versionPath, "installation");
   let source = Directories.currentVersion;
 
   log(
@@ -37,17 +36,17 @@ let switchVersion = (~version, ~quiet) => {
       "Linking "
       <Pastel color=Pastel.Cyan> source </Pastel>
       " to "
-      <Pastel color=Pastel.Cyan> destination </Pastel>
+      <Pastel color=Pastel.Cyan> versionPath </Pastel>
     </Pastel>,
   );
 
   let%lwt _ = Lwt_unix.unlink(Directories.currentVersion) |> lwtIgnore;
-  let%lwt _ = Lwt_unix.symlink(destination, Directories.currentVersion)
+  let%lwt _ = Lwt_unix.symlink(versionPath, Directories.currentVersion)
   and defaultAliasExists = Lwt_unix.file_exists(Directories.defaultVersion);
 
   let%lwt _ =
     if (!defaultAliasExists) {
-      Versions.Aliases.set(~alias="default", ~versionPath=destination);
+      Versions.Aliases.set(~alias="default", ~versionPath);
     } else {
       Lwt.return();
     };

--- a/library/Versions.re
+++ b/library/Versions.re
@@ -31,9 +31,17 @@ module Local = {
     aliases: list(string),
   };
 
-  let systemVersion: t = {name: "system", fullPath: "/dev/null", aliases: []};
+  let systemVersion: t = {
+    name: "system",
+    fullPath: "/dev/null/installation",
+    aliases: [],
+  };
 
-  let toDirectory = name => Filename.concat(Directories.nodeVersions, name);
+  let toDirectory = name =>
+    Filename.concat(
+      Filename.concat(Directories.nodeVersions, name),
+      "installation",
+    );
 
   let getLatestInstalledNameByPrefix = prefix => {
     open Lwt;


### PR DESCRIPTION
Using the pure OCaml `realpath` had its tool and made aliases don't work. This fixes it