### PR TITLE
Add `default`, as a shortcut for `alias default`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ Lists the installed Node versions.
 
 Lists the Node versions available to download remotely.
 
+### `fnm alias [VERSION] [NAME]`
+
+Aliases a Node version to a given name.
+
+### `fnm default [VERSION]`
+
+Aliases a Node version as default. Uses `fnm alias` underneath.
+
 ### `fnm env [--multi] [--shell=fish|bash|zsh] [--node-dist-mirror=URI] [--use-on-cd] [--base-dir=DIR] [--log-level=quiet|error|all]`
 
 Prints the required shell commands in order to configure your shell, Bash compliant by default.

--- a/executable/FnmApp.re
+++ b/executable/FnmApp.re
@@ -3,6 +3,7 @@ let version = Fnm.Fnm__Package.version;
 module Commands = {
   let use = (version, quiet) => Lwt_main.run(Use.run(~version, ~quiet));
   let alias = (version, name) => Lwt_main.run(Alias.run(~name, ~version));
+  let default = (version, name) => Lwt_main.run(Alias.run(~name, ~version));
   let listRemote = () => Lwt_main.run(ListRemote.run());
   let listLocal = () => Lwt_main.run(ListLocal.run());
   let install = version => Lwt_main.run(Install.run(~version));
@@ -170,6 +171,33 @@ let alias = {
   );
 };
 
+let default = {
+  let doc = "Alias a version as default";
+  let man = [];
+  let sdocs = Manpage.s_common_options;
+
+  let selectedVersion = {
+    let doc = "The version to be aliased as default";
+    Arg.(
+      required
+      & pos(0, some(string), None)
+      & info([], ~docv="VERSION", ~doc)
+    );
+  };
+
+  (
+    Term.(const(Commands.alias) $ selectedVersion $ const("default")),
+    Term.info(
+      "default",
+      ~version,
+      ~doc,
+      ~exits=Term.default_exits,
+      ~man,
+      ~sdocs,
+    ),
+  );
+};
+
 let env = {
   let doc = "Show env configurations";
   let sdocs = Manpage.s_common_options;
@@ -268,6 +296,6 @@ let defaultCmd = {
 let _ =
   Term.eval_choice(
     defaultCmd,
-    [install, uninstall, use, alias, listLocal, listRemote, env],
+    [install, uninstall, use, alias, default, listLocal, listRemote, env],
   )
   |> Term.exit;

--- a/executable/FnmApp.re
+++ b/executable/FnmApp.re
@@ -3,7 +3,8 @@ let version = Fnm.Fnm__Package.version;
 module Commands = {
   let use = (version, quiet) => Lwt_main.run(Use.run(~version, ~quiet));
   let alias = (version, name) => Lwt_main.run(Alias.run(~name, ~version));
-  let default = (version, name) => Lwt_main.run(Alias.run(~name, ~version));
+  let default = version =>
+    Lwt_main.run(Alias.run(~name="default", ~version));
   let listRemote = () => Lwt_main.run(ListRemote.run());
   let listLocal = () => Lwt_main.run(ListLocal.run());
   let install = version => Lwt_main.run(Install.run(~version));
@@ -186,7 +187,7 @@ let default = {
   };
 
   (
-    Term.(const(Commands.alias) $ selectedVersion $ const("default")),
+    Term.(const(Commands.default) $ selectedVersion),
     Term.info(
       "default",
       ~version,

--- a/feature_tests/aliases/run.sh
+++ b/feature_tests/aliases/run.sh
@@ -7,8 +7,10 @@ fnm install 8.11.3
 
 fnm alias 8.11.3 oldie
 fnm alias 6.11.3 older
+fnm default 6.11.3 
 
 VERSIONS_INSTALLED=$(fnm ls)
 
 echo "$VERSIONS_INSTALLED" | grep 8.11.3 | grep oldie
 echo "$VERSIONS_INSTALLED" | grep 6.11.3 | grep older
+echo "$VERSIONS_INSTALLED" | grep 6.11.3 | grep default


### PR DESCRIPTION
Fixes #73 

Hey Schniz, this is the draft PR for the default command. Is this something you still want?

How do I actually run your feature tests? Below are my attempts:
 
`feature_tests/run.sh` => "No binary supplied!"
`feature_tests/aliases/run.sh` => "feature_tests/aliases/run.sh: Permission denied"