### PR TITLE
Deprecates MacOS installation using the script in favor of Homebrew

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -2,18 +2,6 @@
 
 set -e
 
-OS=$(uname -s)
-
-if [ "$OS" == "Darwin" ]; then
-  FILENAME="fnm-macos"
-elif [ "$OS" == "Linux" ]; then
-  FILENAME="fnm-linux"
-else
-  echo "OS $OS is not supported."
-  echo "If you think that's a bug - please file an issue to https://github.com/Schniz/fnm/issues"
-  exit 1
-fi
-
 INSTALL_DIR="$HOME/.fnm"
 
 # Parse Flags
@@ -31,12 +19,39 @@ parse_args() {
       SKIP_SHELL="true"
       shift # past argument
       ;;
+    --force-install)
+      FORCE_INSTALL="true"
+      shift
+      ;;
     *)
       echo "Unrecognized argument $key"
       exit 1
       ;;
     esac
   done
+}
+
+set_filename() {
+  local OS
+
+  OS=$(uname -s)
+
+  if [ "$OS" == "Linux" ]; then
+    FILENAME="fnm-linux"
+  elif [ "$OS" == "Darwin" ] && [ "$FORCE_INSTALL" == "true" ]; then
+    FILENAME="fnm-macos"
+  elif [ "$OS" == "Darwin" ]; then
+    echo "Hey! Thanks for trying fnm."
+    echo "MacOS installation works better using Homebrew."
+    echo "Please consider installing using:"
+    echo "    $ brew install Schniz/tap/fnm"
+    echo "or run the script again with the \`--force-install\` option."
+    exit 1
+  else
+    echo "OS $OS is not supported."
+    echo "If you think that's a bug - please file an issue to https://github.com/Schniz/fnm/issues"
+    exit 1
+  fi
 }
 
 download_fnm() {
@@ -134,6 +149,7 @@ setup_shell() {
 }
 
 parse_args "$@"
+set_filename
 check_dependencies
 download_fnm
 if [ "$SKIP_SHELL" != "true" ]; then

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -20,6 +20,7 @@ parse_args() {
       shift # past argument
       ;;
     --force-install)
+      echo "\`--force-install\`: I hope you know what you're doing." >&2
       FORCE_INSTALL="true"
       shift
       ;;

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For `bash`, `zsh` and `fish` shells, there's an [automatic installation script](
 curl -fsSL https://github.com/Schniz/fnm/raw/master/.ci/install.sh | bash
 ```
 
-### Upgrade 
+### Upgrade
 
 Upgrading `fnm` is almost the same as installing it. To prevent duplication in your shell config file add `--skip-shell` to install command.
 
@@ -49,6 +49,10 @@ Set a custom directory for fnm to be installed. The default is `$HOME/.fnm`.
 `--skip-shell`
 
 Skip appending shell specific loader to shell config file, based on the current user shell, defined in `$SHELL`. e.g. for Bash, `$HOME/.bashrc`. `$HOME/.zshrc` for Zsh. For Fish - `$HOME/.config/fish/config.fish`
+
+`--force-install`
+
+MacOS installations using the installation script are deprecated in favor of the Homebrew formula, but this forces the script to install using it anyway.
 
 Example:
 


### PR DESCRIPTION
There are some issues around the installation on MacOS using the script.
I'm not a fan of installation scripts and I'd rather see people use a decent package manager instead of reinventing the wheel here.

So this PR makes the script no longer support OSX (unless provided `--force-install`, which in this case, "I hope you know what you're doing" :smirk:)

Closes #124 
Addresses https://github.com/Schniz/fnm/issues/110#issuecomment-512671929