### PR TITLE
Alias -v to --version

### DIFF
--- a/executable/FnmApp.re
+++ b/executable/FnmApp.re
@@ -351,9 +351,19 @@ let defaultCmd = {
   );
 };
 
+let argv =
+  Sys.argv
+  |> Array.map(arg =>
+       switch (arg) {
+       | "-v" => "--version"
+       | x => x
+       }
+     );
+
 let _ =
   Term.eval_choice(
     defaultCmd,
     [install, uninstall, use, alias, default, listLocal, listRemote, env],
+    ~argv,
   )
   |> Term.exit;


### PR DESCRIPTION
I can't find a way to do it natively in Cmdliner (as opposed to something like showing Help), so this small hack solves it

Fixes #126

I'm waiting for a response on https://github.com/dbuenzli/cmdliner/issues/112, to know if there's a better way to do it.