### PR TITLE
Drop buildsInSource

### DIFF
--- a/.ci/create-static-binary.sh
+++ b/.ci/create-static-binary.sh
@@ -6,5 +6,5 @@ docker build . -t schlez/fnm-static-binary
 
 echo "Copying to ./fnm"
 
-docker run --rm -v $(pwd):$(pwd) --workdir $(pwd) schlez/fnm-static-binary cp /app/_build/default/executable/FnmApp.exe ./fnm
+docker run --rm -v $(pwd):$(pwd) --workdir $(pwd) schlez/fnm-static-binary cp /app/_esy/default/build/default/executable/FnmApp.exe ./fnm
 strip ./fnm

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,14 +43,14 @@ jobs:
   # - template: .ci/restore-build-cache.yml
   - script: brew install fish
   - template: .ci/esy-build-steps.yml
-  - script: cp _build/default/executable/FnmApp.exe _build/fnm
-  - script: strip _build/fnm
-  - script: ./feature_tests/run.sh $(pwd)/_build/fnm
+  - script: cp _esy/default/build/default/executable/FnmApp.exe _esy/default/build/fnm
+  - script: strip _esy/default/build/fnm
+  - script: ./feature_tests/run.sh $(pwd)/_esy/default/build/fnm
   # - template: .ci/publish-build-cache.yml
   - task: PublishBuildArtifacts@1
     displayName: 'Save artifact'
     inputs:
-        PathtoPublish: '_build/fnm'
+        PathtoPublish: '_esy/default/build/fnm'
         ArtifactName: fnm-macos
 
 - job: Windows

--- a/docs/record_screen.sh
+++ b/docs/record_screen.sh
@@ -4,7 +4,7 @@ DIRECTORY=`dirname $0`
 
 function setup_binary() {
   export TEMP_DIR=$(mktemp -d -t fnm)
-  cp _build/default/executable/FnmApp.exe $TEMP_DIR/fnm
+  cp _esy/default/build/default/executable/FnmApp.exe $TEMP_DIR/fnm
   export PATH=$TEMP_DIR:$PATH
   export FNM_DIR=$TEMP_DIR/.fnm
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Fast and simple Node.js version manager, built in ReasonML",
   "esy": {
     "build": "pesy",
-    "buildsInSource": "_build",
     "release": {
       "releasedBinaries": [
         "fnm.exe"

--- a/test/TestFramework.re
+++ b/test/TestFramework.re
@@ -15,7 +15,8 @@ include Rely.Make({
 
 let run = args => {
   let arguments =
-    args |> Array.append([|"./_build/default/executable/FnmApp.exe"|]);
+    args
+    |> Array.append([|"./_esy/default/build/default/executable/FnmApp.exe"|]);
   let env =
     Unix.environment()
     |> Array.append([|


### PR DESCRIPTION
This will help Reason Language Server work with fnm.

Thanks to @thomsj for letting me know about it!

This also removes the resolution for `macaddr` so it uses v4.