### PR TITLE
Make `env` smoke test pass when run with fish

### DIFF
--- a/test/SmokeTest.re
+++ b/test/SmokeTest.re
@@ -11,7 +11,7 @@ describe("Smoke test", ({test, _}) => {
   });
 
   test("env", ({expect}) => {
-    let env = run([|"env"|]) |> redactSfwRoot;
+    let env = run([|"env", "--shell=bash"|]) |> redactSfwRoot;
     expect.string(env).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Ensure esy `test` script runs `TestFnm.exe` as child of bash process, as
`env` smoke test fails when parent process is fish.