### PR TITLE
Add missing `exit 1`s to `partial_semver` tests

### DIFF
--- a/feature_tests/partial_semver/run.sh
+++ b/feature_tests/partial_semver/run.sh
@@ -10,9 +10,11 @@ fnm install 8.11.3
 fnm use 6
 if [ "$(node -v)" != "v6.17.1" ]; then
   echo "Node version mismatch: $(node -v). Expected: v6.17.1"
+  exit 1
 fi
 
 fnm use 8
 if [ "$(node -v)" != "v8.11.3" ]; then
   echo "Node version mismatch: $(node -v). Expected: v8.11.3"
+  exit 1
 fi


### PR DESCRIPTION
Mentioned in #149.