### PR TITLE
Uncapitalise "Node" in `--multi` description

### DIFF
--- a/executable/FnmApp.re
+++ b/executable/FnmApp.re
@@ -283,7 +283,7 @@ let env = {
   };
 
   let isMultishell = {
-    let doc = "Allow different Node versions for each shell";
+    let doc = "Allow different node versions for each shell";
     Arg.(value & flag & info(["multi"], ~doc));
   };
 


### PR DESCRIPTION
Convert "Node" to "node" to improve consistency, as "node" is used     
throughout the manpages.