### PR TITLE
Fix #181 by dropping `exit(1)`

### DIFF
--- a/executable/Alias.re
+++ b/executable/Alias.re
@@ -16,19 +16,19 @@ let run = (~name, ~version) => {
         versionPath
       </Pastel>,
     );
-    exit(1);
+    Lwt.return_error(1);
+  } else {
+    Logger.info(
+      <Pastel>
+        "Aliasing "
+        <Pastel color=Pastel.Cyan> name </Pastel>
+        " to "
+        <Pastel color=Pastel.Cyan> version </Pastel>
+      </Pastel>,
+    );
+
+    let%lwt () = Versions.Aliases.set(~alias=name, ~versionPath);
+
+    Lwt.return_ok();
   };
-
-  Logger.info(
-    <Pastel>
-      "Aliasing "
-      <Pastel color=Pastel.Cyan> name </Pastel>
-      " to "
-      <Pastel color=Pastel.Cyan> version </Pastel>
-    </Pastel>,
-  );
-
-  let%lwt () = Versions.Aliases.set(~alias=name, ~versionPath);
-
-  Lwt.return();
 };

--- a/executable/Env.re
+++ b/executable/Env.re
@@ -158,5 +158,5 @@ let run =
     printUseOnCd(~shell) |> Console.log;
   };
 
-  Lwt.return();
+  Lwt.return_ok();
 };

--- a/executable/FnmApp.re
+++ b/executable/FnmApp.re
@@ -1,14 +1,23 @@
 let version = Fnm.Fnm__Package.version;
 
+let runCmd = lwt => {
+  lwt
+  |> Lwt_main.run
+  |> (
+    fun
+    | Error(err_code) => exit(err_code)
+    | Ok () => ()
+  );
+};
+
 module Commands = {
-  let use = (version, quiet) => Lwt_main.run(Use.run(~version, ~quiet));
-  let alias = (version, name) => Lwt_main.run(Alias.run(~name, ~version));
-  let default = version =>
-    Lwt_main.run(Alias.run(~name="default", ~version));
-  let listRemote = () => Lwt_main.run(ListRemote.run());
-  let listLocal = () => Lwt_main.run(ListLocal.run());
-  let install = version => Lwt_main.run(Install.run(~version));
-  let uninstall = version => Lwt_main.run(Uninstall.run(~version));
+  let use = (version, quiet) => Use.run(~version, ~quiet) |> runCmd;
+  let alias = (version, name) => Alias.run(~name, ~version) |> runCmd;
+  let default = version => Alias.run(~name="default", ~version) |> runCmd;
+  let listRemote = () => ListRemote.run() |> runCmd;
+  let listLocal = () => ListLocal.run() |> runCmd;
+  let install = version => Install.run(~version) |> runCmd;
+  let uninstall = version => Uninstall.run(~version) |> runCmd;
   let env =
       (
         isFishShell,
@@ -19,16 +28,15 @@ module Commands = {
         useOnCd,
         logLevel,
       ) =>
-    Lwt_main.run(
-      Env.run(
-        ~forceShell=Fnm.System.Shell.(isFishShell ? Some(Fish) : shell),
-        ~multishell=isMultishell,
-        ~nodeDistMirror,
-        ~fnmDir,
-        ~useOnCd,
-        ~logLevel,
-      ),
-    );
+    Env.run(
+      ~forceShell=Fnm.System.Shell.(isFishShell ? Some(Fish) : shell),
+      ~multishell=isMultishell,
+      ~nodeDistMirror,
+      ~fnmDir,
+      ~useOnCd,
+      ~logLevel,
+    )
+    |> runCmd;
 };
 
 open Cmdliner;

--- a/executable/Install.re
+++ b/executable/Install.re
@@ -123,7 +123,7 @@ let main = (~version as versionName) => {
       Lwt.return_unit;
     };
 
-  Lwt.return();
+  Lwt.return_ok();
 };
 
 let run = (~version) =>
@@ -139,7 +139,7 @@ let run = (~version) =>
         <Pastel color=Pastel.Cyan> {System.NodeArch.toString(arch)} </Pastel>
       </Pastel>,
     );
-    exit(1);
+    Lwt.return_error(1);
   | Versions.Version_not_found(version) =>
     Logger.error(
       <Pastel>
@@ -148,7 +148,7 @@ let run = (~version) =>
         " not found!"
       </Pastel>,
     );
-    exit(1);
+    Lwt.return_error(1);
   | VersionListingLts.Problem_with_finding_latest_lts(
       VersionListingLts.Cant_find_latest_lts,
     ) =>
@@ -163,5 +163,5 @@ let run = (~version) =>
         reason
       </Pastel>,
     );
-    exit(1);
+    Lwt.return_error(1);
   };

--- a/executable/ListLocal.re
+++ b/executable/ListLocal.re
@@ -31,12 +31,13 @@ let main = () =>
            Console.log(<Pastel ?color> "* " {version.name} aliases </Pastel>);
          });
 
-      Lwt.return();
+      Lwt.return_ok();
     }
   );
 
 let run = () =>
   try%lwt(main()) {
   | Cant_read_local_versions =>
-    Console.log("No versions installed!") |> Lwt.return
+    Console.log("No versions installed!");
+    Lwt.return_ok();
   };

--- a/executable/ListRemote.re
+++ b/executable/ListRemote.re
@@ -22,5 +22,5 @@ let run = () => {
        Console.log(<Pastel ?color> str </Pastel>);
      });
 
-  Lwt.return();
+  Lwt.return_ok();
 };

--- a/executable/Uninstall.re
+++ b/executable/Uninstall.re
@@ -17,7 +17,7 @@ let run = (~version) => {
         " is not installed."
       </Pastel>,
     );
-    exit(1);
+    Lwt.return_error(1);
   | Some(installedVersion) =>
     Logger.debug(
       <Pastel>
@@ -37,6 +37,6 @@ let run = (~version) => {
         " has correctly been removed."
       </Pastel>,
     );
-    Lwt.return_unit;
+    Lwt.return_ok();
   };
 };


### PR DESCRIPTION
Seems that Lwt 5 throws a weird error when using `exit(1)` inside a
promise. So instead of exiting in the command, making all executable
modules a function that returns a `result((), status_code)` is a better fit.

Relates to: https://github.com/ocsigen/lwt/issues/758