### PR TITLE
uninstall allow prefix (fix #121)

### DIFF
--- a/test/TestFnm.re
+++ b/test/TestFnm.re
@@ -1,5 +1,6 @@
 include SmokeTest;
 include TestSemver;
 include TestFs;
+include TestUninstall;
 
 TestFramework.cli();

--- a/test/TestUninstall.re
+++ b/test/TestUninstall.re
@@ -1,0 +1,54 @@
+open TestFramework;
+
+let installVersion = version => run([|"install", version|]);
+let uninstallVersion = version => run([|"uninstall", version|]);
+
+let isVersionInstalled = version =>
+  run([|"ls"|])
+  |> String.split_on_char('\n')
+  |> List.exists(v => v == "* v" ++ version);
+
+describe("Uninstall", ({test}) => {
+  test("Should be possible to uninstall a specific version", ({expect, _}) => {
+    let version = "6.0.0";
+    let _ = installVersion(version);
+    let response = uninstallVersion(version);
+    expect.string(response).toMatch(
+      ".*v" ++ version ++ ".* has correctly been removed.*",
+    );
+    expect.bool(isVersionInstalled(version)).toBeFalse();
+  });
+  test(
+    "Should print out a message if multiple versions match the prefix",
+    ({expect, _}) => {
+    let v1 = "6.10.0";
+    let v2 = "6.11.0";
+    let _ = installVersion(v1);
+    let _ = installVersion(v2);
+    let response =
+      uninstallVersion("6")
+      |> String.split_on_char('\n')
+      |> String.concat(" ");
+    expect.string(response).toMatch(
+      ".*multiple versions.*" ++ v1 ++ ".*" ++ v2 ++ ".*",
+    );
+    expect.bool(isVersionInstalled(v1)).toBeTrue();
+    expect.bool(isVersionInstalled(v2)).toBeTrue();
+    clearTmpDir();
+  });
+  test(
+    "Should be able to uninstall with a prefix if only one version match",
+    ({expect, _}) => {
+    let v1 = "6.10.0";
+    let v2 = "6.11.0";
+    let _ = installVersion(v1);
+    let _ = installVersion(v2);
+    let response = uninstallVersion("6.10");
+    expect.string(response).toMatch(
+      ".*v" ++ v1 ++ ".* has correctly been removed.*",
+    );
+    expect.bool(isVersionInstalled(v1)).toBeFalse();
+    expect.bool(isVersionInstalled(v2)).toBeTrue();
+    clearTmpDir();
+  });
+});


### PR DESCRIPTION
Trying to fix #121. I still need to write the tests but so you can already have a look and give your comments.

The logic goes like this:

* If no version is matching => we print out a message (like we used to)
* If only one version is matching (because the user provided a specific version `6.17.1` or because the prefix match only one installed version) => the version get uninstalled
* If multiple installed versions are matched: we print out the matching installed versions and ask the user to re-run the command with the correct version to uninstall.

Note: it's not possible to uninstall using `latest` or `latest-v9.x`, ... But that's already the case so nothing has changed here.

