### PR TITLE
Create alias from version range (fix #185)

### DIFF
--- a/executable/Alias.re
+++ b/executable/Alias.re
@@ -2,33 +2,32 @@ open Fnm;
 
 let run = (~name, ~version) => {
   let version = Versions.format(version);
-  let versionPath =
-    Filename.concat(
-      Filename.concat(Directories.nodeVersions, version),
-      "installation",
-    );
-  let%lwt versionInstalled = Lwt_unix.file_exists(versionPath);
+  let%lwt matchingLocalVersions =
+    LocalVersionResolver.getMatchingLocalVersions(version);
 
-  if (!versionInstalled) {
-    Logger.error(
-      <Pastel color=Pastel.Red>
-        "Can't find a version installed in "
-        versionPath
-      </Pastel>,
-    );
-    Lwt.return_error(1);
-  } else {
+  switch (Base.List.hd(matchingLocalVersions)) {
+  | Some(latestMatchingLocalVersion) =>
     Logger.info(
       <Pastel>
         "Aliasing "
         <Pastel color=Pastel.Cyan> name </Pastel>
         " to "
-        <Pastel color=Pastel.Cyan> version </Pastel>
+        <Pastel color=Pastel.Cyan> {latestMatchingLocalVersion.name} </Pastel>
       </Pastel>,
     );
 
-    let%lwt () = Versions.Aliases.set(~alias=name, ~versionPath);
-
+    let%lwt () =
+      Versions.Aliases.set(
+        ~alias=name,
+        ~versionPath=latestMatchingLocalVersion.fullPath,
+      );
     Lwt.return_ok();
+  | None =>
+    Logger.error(
+      <Pastel color=Pastel.Red>
+        "No installed versions found that match your criteria."
+      </Pastel>,
+    );
+    Lwt.return_error(1);
   };
 };

--- a/executable/Alias.re
+++ b/executable/Alias.re
@@ -19,7 +19,11 @@ let run = (~name, ~version) => {
     let%lwt () =
       Versions.Aliases.set(
         ~alias=name,
-        ~versionPath=latestMatchingLocalVersion.fullPath,
+        ~versionPath=
+          Filename.concat(
+            latestMatchingLocalVersion.fullPath,
+            "installation",
+          ),
       );
     Lwt.return_ok();
   | None =>


### PR DESCRIPTION
Based on #194 to benefit from the `LocalVersionResolver` module. So I guess this PR should be merged first. This should fix #185 

To be consistent with the `use` command, we could propose to download and alias the version if not yet installed. What do you think?