### PR TITLE
Improve eval expression in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ curl -fsSL https://github.com/Schniz/fnm/raw/master/.ci/install.sh | bash -s -- 
 - Add the following line to your `.bashrc`/`.zshrc` file:
 
   ```bash
-  eval "`fnm env --multi`"
+  eval "$(fnm env --multi)"
   ```
 
   If you are using [fish shell](https://fishshell.com/), add this line to your `config.fish` file:


### PR DESCRIPTION
Hello,

I noticed this detail when reading the manual.

The $(command) expression is preferred instead of backticks.
c.f https://google.github.io/styleguide/shellguide.html#command-substitution

Thanks for this project !