### PR TITLE
Allow aliasing and removing an alias

### DIFF
--- a/library/LocalVersionResolver.re
+++ b/library/LocalVersionResolver.re
@@ -31,6 +31,7 @@ let getMatchingLocalVersions = version => {
     |> List.filter(v =>
          Versions.isVersionFitsPrefix(formattedVersionName, v.name)
          || v.name == formattedVersionName
+         || List.exists(alias => alias == formattedVersionName, v.aliases)
        )
     |> List.sort((a, b) => - compare(a.name, b.name));
 


### PR DESCRIPTION
Fixes #159.

But it won't follow the alias versions: once you alias it will take the concrete version and will alias to it.
This PR also makes it possible to remove a version using an alias.