### PR TITLE
Refactor `fnm current` test suite

### DIFF
--- a/feature_tests/current/run.sh
+++ b/feature_tests/current/run.sh
@@ -2,9 +2,7 @@
 
 set -e
 
-PATH="$(pwd)":$PATH # simulating a custom `node`
-
-eval "$(fnm env)"
+eval "$(fnm env --multi)"
 
 if [ "$(fnm current)" != "none" ]; then
   echo "Expected currently activated version is not none!"
@@ -12,7 +10,6 @@ if [ "$(fnm current)" != "none" ]; then
 fi
 
 fnm install v8.11.3
-fnm install v10.10.0
 fnm use v8.11.3
 
 if [ "$(fnm current)" != "v8.11.3" ]; then
@@ -20,6 +17,14 @@ if [ "$(fnm current)" != "v8.11.3" ]; then
   exit 1
 fi
 
+fnm use system
+
+if [ "$(fnm current)" != "system" ]; then
+  echo "Expected currently activated version is not system!"
+  exit 1
+fi
+
+fnm install v10.10.0
 fnm use v10.10.0
 
 if [ "$(fnm current)" != "v10.10.0" ]; then
@@ -27,7 +32,7 @@ if [ "$(fnm current)" != "v10.10.0" ]; then
   exit 1
 fi
 
-fnm use system
+fnm uninstall v10.10.0
 
 if [ "$(fnm current)" != "system" ]; then
   echo "Expected currently activated version is not system!"

--- a/feature_tests/use_on_cd/run.sh
+++ b/feature_tests/use_on_cd/run.sh
@@ -76,7 +76,7 @@ if hash fish 2>/dev/null; then
     end
   '
 else
-  echo "Skipping fish test: \`zsh\` is not installed"
+  echo "Skipping fish test: \`fish\` is not installed"
 fi
 
 echo " > Running test on Bash..."

--- a/library/Versions.re
+++ b/library/Versions.re
@@ -204,7 +204,8 @@ exception No_Download_For_System(System.NodeOS.t, System.NodeArch.t);
 
 let getCurrentVersion = () =>
   switch%lwt (Fs.realpath(Directories.currentVersion)) {
-  | Missing(x) when x == Directories.currentVersion => Lwt.return_none
+  | Missing(x)
+      when x == Directories.currentVersion || x == Directories.defaultVersion => Lwt.return_none
   | Missing(_) => Lwt.return_some(Local.systemVersion)
   | Exists(installationPath) =>
     let fullPath = Filename.dirname(installationPath);


### PR DESCRIPTION
This is a continuation of #220 I cleaned up the test and fixed incorrect current version reporting in multishell mode.