### PR TITLE
Remove unused condition

### DIFF
--- a/executable/Env.re
+++ b/executable/Env.re
@@ -80,10 +80,10 @@ let printUseOnCd = (~shell) =>
     __fnmcd () {
       cd "$@"
 
-      if [[ -f .node-version && .node-version ]]; then
+      if [[ -f .node-version && -r .node-version ]]; then
         echo "fnm: Found .node-version"
         fnm use
-      elif [[ -f .nvmrc && .nvmrc ]]; then
+      elif [[ -f .nvmrc && -r .nvmrc ]]; then
         echo "fnm: Found .nvmrc"
         fnm use
       fi


### PR DESCRIPTION
This just checks if ".node-version" is a non-empty string, which is
always true.

------

Was this meant to check if the file is non-empty? If so, I can send another pull request that `stat`'s the file.