### PR TITLE
Feature/support ash

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -110,7 +110,7 @@ check_dependencies() {
 }
 
 setup_shell() {
-  CURRENT_SHELL=$(basename $SHELL)
+  CURRENT_SHELL=$(basename $0)
 
   if [ "$CURRENT_SHELL" == "zsh" ]; then
     CONF_FILE=$HOME/.zshrc
@@ -145,6 +145,19 @@ setup_shell() {
       CONF_FILE=$HOME/.bashrc
     fi
     echo "Installing for Bash. Appending the following to $CONF_FILE:"
+    echo ""
+    echo '  # fnm'
+    echo '  export PATH='"$INSTALL_DIR"':$PATH'
+    echo '  eval "`fnm env --multi`"'
+
+    echo '' >>$CONF_FILE
+    echo '# fnm' >>$CONF_FILE
+    echo 'export PATH='"$INSTALL_DIR"':$PATH' >>$CONF_FILE
+    echo 'eval "`fnm env --multi`"' >>$CONF_FILE
+
+  elif [ "$CURRENT_SHELL" == "ash" ]; then
+    CONF_FILE=$HOME/.ashrc
+    echo "Installing for Ash. Appending the following to $CONF_FILE:"
     echo ""
     echo '  # fnm'
     echo '  export PATH='"$INSTALL_DIR"':$PATH'

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -110,7 +110,7 @@ check_dependencies() {
 }
 
 setup_shell() {
-  CURRENT_SHELL=$(basename $0)
+  CURRENT_SHELL=$(basename $SHELL)
 
   if [ "$CURRENT_SHELL" == "zsh" ]; then
     CONF_FILE=$HOME/.zshrc

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ brew install Schniz/tap/fnm
 
 ### Using a script
 
-For `bash`, `zsh` and `fish` shells, there's an [automatic installation script](./.ci/install.sh):
+For `bash`, `zsh`, `ash` and `fish` shells, there's an [automatic installation script](./.ci/install.sh):
 
 ```bash
 curl -fsSL https://github.com/Schniz/fnm/raw/master/.ci/install.sh | bash


### PR DESCRIPTION
I wanted to install `fnm` on an alpine docker image, but got an error because `ash` is not supported by the installation script. This simple PR aims to solve that.

I also had another issue regarding the use of `$SHELL`:
```sh
/ # echo $SHELL


/ # basename $SHELL
basename: missing operand
Try 'basename --help' for more information.
```
$SHELL was empty when accessing via docker, so `basename` does not work providing an empty value. I solved this by doing `SHELL=($which ash)` on the image, I don't think that's an optimal solution but a workaround. 
Any thoughts about this? maybe providing a default install method (bash?) or printing a warning when no $SHELL is set 🤔 