### PR TITLE
docs: add explanation of uninstall command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Lists the installed Node versions.
 
 Lists the Node versions available to download remotely.
 
+### `fnm uninstall [VERSION]`
+
+Uninstalls the node version specified in `[VERSION]`.
+
 ### `fnm alias [VERSION] [NAME]`
 
 Aliases a Node version to a given name.


### PR DESCRIPTION
This PR adds a description of the `uninstall` command to README since it was not mentioned.