### PR TITLE
Allow using homebrew to install with the installation script

### DIFF
--- a/.ci/get_shell_profile.sh
+++ b/.ci/get_shell_profile.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+OS="$(uname -s)"
+
+case $1 in
+  "fish")
+    CONFIG_DIR="$(fish -c 'echo -n $__fish_config_dir')"
+    echo "${CONFIG_DIR-"$HOME/.config/fish"}/fish.config"
+    ;;
+  "zsh")
+    echo "$HOME/.zshrc"
+    ;;
+  "bash")
+    if [ "$OS" = "Darwin" ]; then
+      echo "$HOME/.profile"
+    else
+      echo "$HOME/.bashrc"
+    fi
+    ;;
+  *)
+    exit 1
+    ;;
+esac

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -20,7 +20,7 @@ parse_args() {
       SKIP_SHELL="true"
       shift # past argument
       ;;
-    --force-install)
+    --force-install | --force-no-brew)
       echo "\`--force-install\`: I hope you know what you're doing." >&2
       FORCE_INSTALL="true"
       shift
@@ -47,13 +47,13 @@ set_filename() {
     FILENAME="fnm-linux"
   elif [ "$OS" == "Darwin" ] && [ "$FORCE_INSTALL" == "true" ]; then
     FILENAME="fnm-macos"
+    USE_HOMEBREW="false"
+    echo "Downloading the latest fnm binary from GitHub..."
+    echo "  Pro tip: it's eaiser to use Homebrew for managing fnm in MacOS."
+    echo "           Remove the \`--force-no-brew\` so it will be easy to upgrade."
   elif [ "$OS" == "Darwin" ]; then
-    echo "Hey! Thanks for trying fnm."
-    echo "MacOS installation works better using Homebrew."
-    echo "Please consider installing using:"
-    echo "    $ brew install Schniz/tap/fnm"
-    echo "or run the script again with the \`--force-install\` option."
-    exit 1
+    USE_HOMEBREW="true"
+    echo "Downloading fnm using Homebrew..."
   else
     echo "OS $OS is not supported."
     echo "If you think that's a bug - please file an issue to https://github.com/Schniz/fnm/issues"
@@ -62,27 +62,31 @@ set_filename() {
 }
 
 download_fnm() {
-  if [ "$RELEASE" == "latest" ]; then
-    URL=https://github.com/Schniz/fnm/releases/latest/download/$FILENAME.zip
+  if [ "$USE_HOMEBREW" == "true" ]; then
+    brew install Schniz/tap/fnm
   else
-    URL=https://github.com/Schniz/fnm/releases/download/$RELEASE/$FILENAME.zip
+    if [ "$RELEASE" == "latest" ]; then
+      URL="https://github.com/Schniz/fnm/releases/latest/download/$FILENAME.zip"
+    else
+      URL="https://github.com/Schniz/fnm/releases/download/$RELEASE/$FILENAME.zip"
+    fi
+
+    DOWNLOAD_DIR=$(mktemp -d)
+
+    echo "Downloading $URL..."
+
+    mkdir -p "$INSTALL_DIR" &>/dev/null
+    curl --progress-bar -L "$URL" -o "$DOWNLOAD_DIR/$FILENAME.zip"
+
+    if [ 0 -ne $? ]; then
+      echo "Download failed.  Check that the release/filename are correct."
+      exit 1
+    fi
+
+    unzip -q "$DOWNLOAD_DIR/$FILENAME.zip" -d "$DOWNLOAD_DIR"
+    mv "$DOWNLOAD_DIR/$FILENAME/fnm" "$INSTALL_DIR/fnm"
+    chmod u+x "$INSTALL_DIR/fnm"
   fi
-  
-  DOWNLOAD_DIR=$(mktemp -d)
-
-  echo "Downloading $URL..."
-
-  mkdir -p $INSTALL_DIR &>/dev/null
-  curl --progress-bar -L $URL -o $DOWNLOAD_DIR/$FILENAME.zip
-
-  if [ 0 -ne $? ]; then 
-    echo "Download failed.  Check that the release/filename are correct."
-    exit 1
-  fi;
-
-  unzip -q $DOWNLOAD_DIR/$FILENAME.zip -d $DOWNLOAD_DIR
-  mv $DOWNLOAD_DIR/$FILENAME/fnm $INSTALL_DIR/fnm
-  chmod u+x $INSTALL_DIR/fnm
 }
 
 check_dependencies() {
@@ -102,6 +106,16 @@ check_dependencies() {
   else
     echo "Missing!"
     SHOULD_EXIT="true"
+  fi
+
+  if [ "$USE_HOMEBREW" = "true" ]; then
+    echo -n "Checking availability of Homebrew (brew)... "
+    if hash brew 2>/dev/null; then
+      echo "OK!"
+    else
+      echo "Missing!"
+      SHOULD_EXIT="true"
+    fi
   fi
 
   if [ "$SHOULD_EXIT" = "true" ]; then

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -63,7 +63,7 @@ set_filename() {
 
 download_fnm() {
   if [ "$USE_HOMEBREW" == "true" ]; then
-    brew install Schniz/tap/fnm
+    brew install Schniz/tap/fnm --quiet
   else
     if [ "$RELEASE" == "latest" ]; then
       URL="https://github.com/Schniz/fnm/releases/latest/download/$FILENAME.zip"

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -63,7 +63,7 @@ set_filename() {
 
 download_fnm() {
   if [ "$USE_HOMEBREW" == "true" ]; then
-    brew install Schniz/tap/fnm --quiet
+    brew install Schniz/tap/fnm > /dev/null
   else
     if [ "$RELEASE" == "latest" ]; then
       URL="https://github.com/Schniz/fnm/releases/latest/download/$FILENAME.zip"

--- a/.ci/test_installation_script.sh
+++ b/.ci/test_installation_script.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+DIRECTORY="$(dirname "$0")"
+SHELL_TO_RUN="$1"
+PROFILE_FILE="$("$DIRECTORY/get_shell_profile.sh" "$SHELL_TO_RUN")"
+
+echo "Profile is $PROFILE_FILE"
+
+$SHELL_TO_RUN -c '
+  fnm install 12.5.0
+  fnm ls | grep 12.5.0
+
+  echo "fnm ls worked."
+'
+
+$SHELL_TO_RUN -c '
+  fnm use 12.5.0
+  node --version | grep 12.5.0
+
+  echo "node --version worked."
+'

--- a/.github/workflows/installation_script.yml
+++ b/.github/workflows/installation_script.yml
@@ -10,7 +10,8 @@ on:
       - .ci/install.sh
 
 jobs:
-  install_on_linux:
+  test_against_latest_release:
+    name: Test against latest release
     strategy:
       matrix:
         shell: [fish, zsh, bash]

--- a/.github/workflows/installation_script.yml
+++ b/.github/workflows/installation_script.yml
@@ -18,7 +18,8 @@ jobs:
         os: [ubuntu, macos]
         force_no_brew: ['--force-no-brew', '']
     runs-on: ${{ matrix.os }}-latest
-    if: ${{ matrix.os }} == 'macos' || ${{ matrix.force_no_brew }} == ''
+    if: |
+      (${{ matrix.os }} == 'macos') || (${{ matrix.force_no_brew }} == '')
     steps:
       - uses: actions/checkout@v2
       - run: "sudo apt-get install -y ${{ matrix.shell }}"

--- a/.github/workflows/installation_script.yml
+++ b/.github/workflows/installation_script.yml
@@ -1,9 +1,13 @@
 name: Installation script
 on: 
   pull_request:
+    paths:
+      - .ci/install.sh
   push:
     branches:
       - master
+    paths:
+      - .ci/install.sh
 
 jobs:
   install_on_linux:

--- a/.github/workflows/installation_script.yml
+++ b/.github/workflows/installation_script.yml
@@ -20,10 +20,10 @@ jobs:
       - uses: actions/checkout@v2
       - run: "sudo apt-get install -y ${{ matrix.shell }}"
         name: Install ${{matrix.shell}} using apt-get
-        if: matrix.os == "ubuntu"
+        if: matrix.os == 'ubuntu'
       - run: "brew install ${{ matrix.shell }}"
         name: Install ${{matrix.shell}} using Homebrew
-        if: matrix.os == "macos"
+        if: matrix.os == 'macos'
       - run: "cp ~/.bashrc ~/.bashrc.bak && echo '. ~/.bashrc.bak' > ~/.bashrc"
         name: reset bashrc file
       - run: "env SHELL=$(which ${{ matrix.shell }}) bash ./.ci/install.sh"

--- a/.github/workflows/installation_script.yml
+++ b/.github/workflows/installation_script.yml
@@ -11,113 +11,60 @@ on:
 
 jobs:
   install_on_linux:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - shell: fish
-            source: ~/.config/fish/config.fish
-          - shell: zsh
-            source: ~/.zshrc
-          - shell: bash
-            source: ~/.bashrc
+        shell: [fish, zsh, bash]
+        os: [ubuntu, macos]
+    runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v2
       - run: "sudo apt-get install -y ${{ matrix.shell }}"
-        name: Install shell
+        name: Install ${{matrix.shell}} using apt-get
+        if: matrix.os == "ubuntu"
+      - run: "brew install ${{ matrix.shell }}"
+        name: Install ${{matrix.shell}} using Homebrew
+        if: matrix.os == "macos"
       - run: "cp ~/.bashrc ~/.bashrc.bak && echo '. ~/.bashrc.bak' > ~/.bashrc"
         name: reset bashrc file
       - run: "env SHELL=$(which ${{ matrix.shell }}) bash ./.ci/install.sh"
         name: Run the installation script
+      - run: ./.ci/test_installation_script.sh ${{ matrix.shell }}
+        name: 'Test installation script'
 
-      - run: |
-          ${{ matrix.shell }} -c '
-            source ${{ matrix.source }}
-            fnm install 12.5.0
-            fnm ls | grep 12.5.0
-          '
-        name: 'Install a Node version with `fnm install`'
+  # install_on_mac_binary:
+  #   runs-on: macos-latest
+  #   strategy:
+  #     matrix:
+  #       include:
+  #         - shell: fish
+  #           source: ~/.config/fish/config.fish
+  #         - shell: zsh
+  #           source: ~/.zshrc
+  #         - shell: bash
+  #           source: ~/.bashrc
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - run: "brew install ${{ matrix.shell }}"
+  #       name: Install shell
+  #     - name: reset bashrc file
+  #       run: |
+  #         cp ~/.bashrc ~/.bashrc.bak
+  #         echo '. ~/.bashrc.bak' > ~/.bashrc
+  #     - run: "env SHELL=$(which ${{ matrix.shell }}) bash ./.ci/install.sh --force-install"
+  #       name: Run the installation script
 
-      - run: |
-          ${{ matrix.shell }} -c '
-            source ${{ matrix.source }}
-            fnm use 12.5.0
-            node --version | grep 12.5.0
-          '
-        name: 'Check switching versions with `fnm use`'
+  #     - name: 'Install a Node version with `fnm install`'
+  #       run: |
+  #         ${{ matrix.shell }} -c '
+  #           source ${{ matrix.source }}
+  #           fnm install 12.5.0
+  #           fnm ls | grep 12.5.0
+  #         '
 
-  install_on_mac_binary:
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        include:
-          - shell: fish
-            source: ~/.config/fish/config.fish
-          - shell: zsh
-            source: ~/.zshrc
-          - shell: bash
-            source: ~/.bashrc
-    steps:
-      - uses: actions/checkout@v2
-      - run: "brew install ${{ matrix.shell }}"
-        name: Install shell
-      - name: reset bashrc file
-        run: |
-          cp ~/.bashrc ~/.bashrc.bak
-          echo '. ~/.bashrc.bak' > ~/.bashrc
-      - run: "env SHELL=$(which ${{ matrix.shell }}) bash ./.ci/install.sh --force-install"
-        name: Run the installation script
-
-      - name: 'Install a Node version with `fnm install`'
-        run: |
-          ${{ matrix.shell }} -c '
-            source ${{ matrix.source }}
-            fnm install 12.5.0
-            fnm ls | grep 12.5.0
-          '
-
-      - name: 'Check switching versions with `fnm use`'
-        run: |
-          ${{ matrix.shell }} -c '
-            source ${{ matrix.source }}
-            fnm use 12.5.0
-            node --version | grep 12.5.0
-          '
-
-  install_on_mac_homebrew:
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        include:
-          - shell: fish
-            source: ~/.config/fish/config.fish
-          - shell: zsh
-            source: ~/.zshrc
-          - shell: bash
-            source: ~/.bashrc
-    steps:
-      - uses: actions/checkout@v2
-      - run: "brew install ${{ matrix.shell }}"
-        name: Install shell
-      - name: reset bashrc file
-        run: |
-          cp ~/.bashrc ~/.bashrc.bak
-          echo '. ~/.bashrc.bak' > ~/.bashrc
-      - run: "env SHELL=$(which ${{ matrix.shell }}) bash ./.ci/install.sh"
-        name: Run the installation script
-
-      - name: 'Install a Node version with `fnm install`'
-        run: |
-          ${{ matrix.shell }} -c '
-            source ${{ matrix.source }}
-            fnm install 12.5.0
-            fnm ls | grep 12.5.0
-          '
-
-      - name: 'Check switching versions with `fnm use`'
-        run: |
-          ${{ matrix.shell }} -c '
-            source ${{ matrix.source }}
-            fnm use 12.5.0
-            node --version | grep 12.5.0
-          '
+  #     - name: 'Check switching versions with `fnm use`'
+  #       run: |
+  #         ${{ matrix.shell }} -c '
+  #           source ${{ matrix.source }}
+  #           fnm use 12.5.0
+  #           node --version | grep 12.5.0
+  #         '

--- a/.github/workflows/installation_script.yml
+++ b/.github/workflows/installation_script.yml
@@ -16,7 +16,9 @@ jobs:
       matrix:
         shell: [fish, zsh, bash]
         os: [ubuntu, macos]
+        force_no_brew: ['--force-no-brew', '']
     runs-on: ${{ matrix.os }}-latest
+    if: matrix.os == 'macos' || matrix.force_no_brew == ''
     steps:
       - uses: actions/checkout@v2
       - run: "sudo apt-get install -y ${{ matrix.shell }}"
@@ -27,7 +29,7 @@ jobs:
         if: matrix.os == 'macos'
       - run: "cp ~/.bashrc ~/.bashrc.bak && echo '. ~/.bashrc.bak' > ~/.bashrc"
         name: reset bashrc file
-      - run: "env SHELL=$(which ${{ matrix.shell }}) bash ./.ci/install.sh"
+      - run: "env SHELL=$(which ${{ matrix.shell }}) bash ./.ci/install.sh ${{ matrix.force_no_brew }}"
         name: Run the installation script
       - run: ./.ci/test_installation_script.sh ${{ matrix.shell }}
         name: 'Test installation script'

--- a/.github/workflows/installation_script.yml
+++ b/.github/workflows/installation_script.yml
@@ -15,22 +15,25 @@ jobs:
     strategy:
       matrix:
         shell: [fish, zsh, bash]
-        os: [ubuntu, macos]
-        force_no_brew: ['--force-no-brew', '']
-    runs-on: ${{ matrix.os }}-latest
-    if: |
-      (${{ matrix.os }} == 'macos') || (${{ matrix.force_no_brew }} == '')
+        setup: 
+          - os: ubuntu
+            script_arguments: ''
+          - os: macos
+            script_arguments: ''
+          - os: macos
+            script_arguments: '--force-no-brew'
+    runs-on: ${{ matrix.setup.os }}-latest
     steps:
       - uses: actions/checkout@v2
       - run: "sudo apt-get install -y ${{ matrix.shell }}"
         name: Install ${{matrix.shell}} using apt-get
-        if: matrix.os == 'ubuntu'
+        if: matrix.setup.os == 'ubuntu'
       - run: "brew install ${{ matrix.shell }}"
         name: Install ${{matrix.shell}} using Homebrew
-        if: matrix.os == 'macos'
+        if: matrix.setup.os == 'macos'
       - run: "cp ~/.bashrc ~/.bashrc.bak && echo '. ~/.bashrc.bak' > ~/.bashrc"
         name: reset bashrc file
-      - run: "env SHELL=$(which ${{ matrix.shell }}) bash ./.ci/install.sh ${{ matrix.force_no_brew }}"
+      - run: "env SHELL=$(which ${{ matrix.shell }}) bash ./.ci/install.sh ${{ matrix.setup.script_arguments }}"
         name: Run the installation script
       - run: ./.ci/test_installation_script.sh ${{ matrix.shell }}
         name: 'Test installation script'

--- a/.github/workflows/installation_script.yml
+++ b/.github/workflows/installation_script.yml
@@ -42,7 +42,7 @@ jobs:
           '
         name: 'Check switching versions with `fnm use`'
 
-  install_on_mac:
+  install_on_mac_binary:
     runs-on: macos-latest
     strategy:
       matrix:
@@ -62,6 +62,44 @@ jobs:
           cp ~/.bashrc ~/.bashrc.bak
           echo '. ~/.bashrc.bak' > ~/.bashrc
       - run: "env SHELL=$(which ${{ matrix.shell }}) bash ./.ci/install.sh --force-install"
+        name: Run the installation script
+
+      - name: 'Install a Node version with `fnm install`'
+        run: |
+          ${{ matrix.shell }} -c '
+            source ${{ matrix.source }}
+            fnm install 12.5.0
+            fnm ls | grep 12.5.0
+          '
+
+      - name: 'Check switching versions with `fnm use`'
+        run: |
+          ${{ matrix.shell }} -c '
+            source ${{ matrix.source }}
+            fnm use 12.5.0
+            node --version | grep 12.5.0
+          '
+
+  install_on_mac_homebrew:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        include:
+          - shell: fish
+            source: ~/.config/fish/config.fish
+          - shell: zsh
+            source: ~/.zshrc
+          - shell: bash
+            source: ~/.bashrc
+    steps:
+      - uses: actions/checkout@v2
+      - run: "brew install ${{ matrix.shell }}"
+        name: Install shell
+      - name: reset bashrc file
+        run: |
+          cp ~/.bashrc ~/.bashrc.bak
+          echo '. ~/.bashrc.bak' > ~/.bashrc
+      - run: "env SHELL=$(which ${{ matrix.shell }}) bash ./.ci/install.sh"
         name: Run the installation script
 
       - name: 'Install a Node version with `fnm install`'

--- a/.github/workflows/installation_script.yml
+++ b/.github/workflows/installation_script.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu, macos]
         force_no_brew: ['--force-no-brew', '']
     runs-on: ${{ matrix.os }}-latest
-    if: matrix.os == 'macos' || matrix.force_no_brew == ''
+    if: ${{ matrix.os }} == 'macos' || ${{ matrix.force_no_brew }} == ''
     steps:
       - uses: actions/checkout@v2
       - run: "sudo apt-get install -y ${{ matrix.shell }}"


### PR DESCRIPTION
I don't really know how to make Homebrew patch the shell profiles
so making the install script use Homebrew might work well.

This will make Homebrew the default installation mechanism for fnm, which is already the case, but now will be supported by the installation script.

This can be overridden and work the same way as the Linux installation the following way:

```bash
curl SCRIPT | bash -s -- --force-no-brew # or --force-install
```


This makes a great follow up question:
Is there a way to automate apt/yum/etc so we'll use real package managers instead of implementing our own for Linux boxes?