### PR TITLE
Use separate config file for fish config

### DIFF
--- a/.ci/get_shell_profile.sh
+++ b/.ci/get_shell_profile.sh
@@ -2,7 +2,7 @@
 
 case $1 in
   "fish")
-    echo "$HOME/.config/fish/config.fish"
+    echo "$HOME/.config/fish/conf.d/fnm.fish"
     ;;
   "zsh")
     echo "$HOME/.zshrc"

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -152,7 +152,7 @@ setup_shell() {
     echo 'eval "`fnm env --multi`"' >>$CONF_FILE
 
   elif [ "$CURRENT_SHELL" == "fish" ]; then
-    CONF_FILE=$HOME/.config/fish/config.fish
+    CONF_FILE=$HOME/.config/fish/conf.d/fnm.fish
     ensure_containing_dir_exists "$CONF_FILE"
     echo "Installing for Fish. Appending the following to $CONF_FILE:"
     echo ""
@@ -160,7 +160,6 @@ setup_shell() {
     echo '  set PATH '"$INSTALL_DIR"' $PATH'
     echo '  fnm env --multi | source'
 
-    echo '' >>$CONF_FILE
     echo '# fnm' >>$CONF_FILE
     echo 'set PATH '"$INSTALL_DIR"' $PATH' >>$CONF_FILE
     echo 'fnm env --multi | source' >>$CONF_FILE

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Set a custom directory for fnm to be installed. The default is `$HOME/.fnm`.
 
 `--skip-shell`
 
-Skip appending shell specific loader to shell config file, based on the current user shell, defined in `$SHELL`. e.g. for Bash, `$HOME/.bashrc`. `$HOME/.zshrc` for Zsh. For Fish - `$HOME/.config/fish/config.fish`
+Skip appending shell specific loader to shell config file, based on the current user shell, defined in `$SHELL`. e.g. for Bash, `$HOME/.bashrc`. `$HOME/.zshrc` for Zsh. For Fish - `$HOME/.config/fish/conf.d/fnm.fish`
 
 `--force-install`
 
@@ -76,11 +76,12 @@ Then apply the changes the installer prints, to set up your shell profile.
   eval "$(fnm env --multi)"
   ```
 
-  If you are using [fish shell](https://fishshell.com/), add this line to your `config.fish` file:
+  If you are using [fish shell](https://fishshell.com/), create `~/.config/fish/confi.d/fnm.fish` add this line to it:
 
   ```fish
   fnm env --multi | source
   ```
+
 ## Completions
 
 - Fish Shell

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Then apply the changes the installer prints, to set up your shell profile.
   eval "$(fnm env --multi)"
   ```
 
-  If you are using [fish shell](https://fishshell.com/), create `~/.config/fish/confi.d/fnm.fish` add this line to it:
+  If you are using [fish shell](https://fishshell.com/), create `~/.config/fish/conf.d/fnm.fish` add this line to it:
 
   ```fish
   fnm env --multi | source


### PR DESCRIPTION
This puts the fish config into a separate file instead of appending it to the main config. This makes it cleaner if you want to remove it later.