### PR TITLE
Add ARM support

### DIFF
--- a/src/system_info.rs
+++ b/src/system_info.rs
@@ -8,12 +8,22 @@ pub fn platform_name() -> &'static str {
     "linux"
 }
 
-#[cfg(target_pointer_width = "32")]
+#[cfg(all(target_pointer_width = "32", target_arch = "arm"))]
+pub fn platform_arch() -> &'static str {
+    "armv7l"
+}
+
+#[cfg(all(target_pointer_width = "32", not(target_arch = "arm")))]
 pub fn platform_arch() -> &'static str {
     "x86"
 }
 
-#[cfg(target_pointer_width = "64")]
+#[cfg(all(target_pointer_width = "64", target_arch = "arm"))]
+pub fn platform_arch() -> &'static str {
+    "arm64"
+}
+
+#[cfg(all(target_pointer_width = "64", not(target_arch = "arm")))]
 pub fn platform_arch() -> &'static str {
     "x64"
 }


### PR DESCRIPTION
This is the code from #222. I tested 64-bit arm (`aarch64`) and x64 but have no 32-bit devices. I'm fairly certain they work too though given the way the logic follows.