### PR TITLE
Fix moving node install out of tmp directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dircpy"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4479788c6c76674c1551ef44c953101554e7edadb5ea0920797a2280d87eb3d"
+dependencies = [
+ "log",
+ "walkdir",
+]
+
+[[package]]
 name = "dirs"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +487,7 @@ dependencies = [
  "clap",
  "colored",
  "csv",
+ "dircpy",
  "dirs",
  "duct",
  "embed-resource",
@@ -1413,6 +1424,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1967,6 +1987,17 @@ checksum = "fc2f5402d3d0e79a069714f7b48e3ecc60be7775a2c049cb839457457a239532"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file",
+ "winapi 0.3.9",
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ log = "0.4.11"
 env_logger = "0.7.1"
 atty = "0.2.14"
 encoding_rs_io = "0.1.7"
+dircpy = "0.3.4"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/src/directory_portal.rs
+++ b/src/directory_portal.rs
@@ -1,3 +1,4 @@
+use dircpy::copy_dir;
 use log::*;
 use std::path::Path;
 use tempfile::{tempdir, TempDir};
@@ -21,7 +22,8 @@ impl<P: AsRef<Path>> DirectoryPortal<P> {
             self.temp_dir.path(),
             self.target.as_ref()
         );
-        std::fs::rename(&self.temp_dir, &self.target)?;
+        copy_dir(&self.temp_dir, &self.target)?;
+        std::fs::remove_dir_all(&self.temp_dir)?;
         Ok(self.target)
     }
 }


### PR DESCRIPTION
Addresses issue in #222 where `fnm install` doesn't work.

Per my comments on there, [`fs::rename`](https://doc.rust-lang.org/std/fs/fn.rename.html) cannot be used to move a directory across mount points, so the current code doesn't work on many Linux systems where `/tmp` is usually on a separate partition than `/home`. 