### PR TITLE
Fix npm not working because of wrong file copying

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,16 +348,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dircpy"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4479788c6c76674c1551ef44c953101554e7edadb5ea0920797a2280d87eb3d"
-dependencies = [
- "log",
- "walkdir",
-]
-
-[[package]]
 name = "dirs"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,7 +477,6 @@ dependencies = [
  "clap",
  "colored",
  "csv",
- "dircpy",
  "dirs",
  "duct",
  "embed-resource",
@@ -1415,15 +1404,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1978,17 +1958,6 @@ checksum = "fc2f5402d3d0e79a069714f7b48e3ecc60be7775a2c049cb839457457a239532"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
-dependencies = [
- "same-file",
- "winapi 0.3.9",
- "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ log = "0.4.11"
 env_logger = "0.8.1"
 atty = "0.2.14"
 encoding_rs_io = "0.1.7"
-dircpy = "0.3.4"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -88,7 +88,11 @@ pub fn install_node_dist<P: AsRef<Path>>(
     );
 
     std::fs::create_dir_all(installations_dir.as_ref()).context(IoError)?;
-    let portal = DirectoryPortal::new(installation_dir);
+
+    let temp_installations_dir = installations_dir.as_ref().join(".downloads");
+    std::fs::create_dir_all(&temp_installations_dir).context(IoError)?;
+
+    let portal = DirectoryPortal::new_in(&temp_installations_dir, installation_dir);
 
     let url = download_url(node_dist_mirror, version);
     debug!("Going to call for {}", &url);
@@ -123,7 +127,6 @@ mod tests {
     use crate::downloader::install_node_dist;
     use crate::version::Version;
     use pretty_assertions::assert_eq;
-    use std::io::Read;
     use tempfile::tempdir;
 
     #[test_env_log::test]
@@ -144,16 +147,36 @@ mod tests {
 
         location_path.push("node");
 
-        let mut result = String::new();
-        std::process::Command::new(location_path.to_str().unwrap())
-            .arg("--version")
-            .stdout(std::process::Stdio::piped())
-            .spawn()
-            .expect("Can't find node executable")
-            .stdout
-            .expect("Can't capture stdout")
-            .read_to_string(&mut result)
-            .expect("Failed reading stdout");
-        assert_eq!(result.trim(), "v12.0.0");
+        let result = duct::cmd(location_path.to_str().unwrap(), vec!["--version"])
+            .stdout_capture()
+            .run()
+            .expect("Can't run Node binary");
+        assert_eq!(result.stdout, b"v12.0.0\n");
+    }
+
+    #[test_env_log::test]
+    fn test_installing_npm() {
+        let version = Version::parse("12.0.0").unwrap();
+        let node_dist_mirror = Url::parse("https://nodejs.org/dist/").unwrap();
+        let installations_dir = tempdir().unwrap();
+        install_node_dist(&version, &node_dist_mirror, &installations_dir)
+            .expect("Can't install Node 12");
+
+        let mut location_path = PathBuf::from(&installations_dir.path());
+        location_path.push(version.v_str());
+        location_path.push("installation");
+
+        if cfg!(unix) {
+            location_path.push("bin");
+        }
+
+        location_path.push("npm");
+
+        let result = duct::cmd(location_path.to_str().unwrap(), vec!["--version"])
+            .stdout_capture()
+            .run()
+            .expect("Can't run npm");
+
+        assert_eq!(result.stdout, b"6.9.0\n");
     }
 }

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -148,7 +148,11 @@ mod tests {
     #[test_env_log::test]
     fn test_installing_npm() {
         let installations_dir = tempdir().unwrap();
-        let npm_path = install_in(installations_dir.path()).join("npm");
+        let npm_path = install_in(installations_dir.path()).join(if cfg!(windows) {
+            "npm.cmd"
+        } else {
+            "npm"
+        });
 
         let stdout = duct::cmd(npm_path.to_str().unwrap(), vec!["--version"])
             .stdout_capture()


### PR DESCRIPTION
> DirectoryPortal: move files instead of copying

The fix in #275 introduced a bug that made `npm` unusable: `dircpy`isn't aware of symlinks, so when it copied the files recursively, it copied the actual file instead of keeping it a symlink. This made
`bin/npm` the actual JS file instead of being a symlink to `../lib/node_modules/npm/whatever`.

This fixes #283