### PR TITLE
Refer to homebrew/core formula instead of custom tap

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -70,7 +70,7 @@ set_filename() {
 
 download_fnm() {
   if [ "$USE_HOMEBREW" == "true" ]; then
-    brew install Schniz/tap/fnm > /dev/null
+    brew install fnm > /dev/null
   else
     if [ "$RELEASE" == "latest" ]; then
       URL="https://github.com/Schniz/fnm/releases/latest/download/$FILENAME.zip"

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -70,7 +70,7 @@ set_filename() {
 
 download_fnm() {
   if [ "$USE_HOMEBREW" == "true" ]; then
-    brew install fnm > /dev/null
+    brew install fnm
   else
     if [ "$RELEASE" == "latest" ]; then
       URL="https://github.com/Schniz/fnm/releases/latest/download/$FILENAME.zip"

--- a/.github/workflows/installation_script.yml
+++ b/.github/workflows/installation_script.yml
@@ -66,8 +66,8 @@ jobs:
       - run: "sudo apt-get install -y ${{ matrix.shell }}"
         name: Install ${{matrix.shell}} using apt-get
         if: matrix.setup.os == 'ubuntu'
-      - run: "brew install ${{ matrix.shell }}"
-        name: Install ${{matrix.shell}} using Homebrew
+      - run: "brew update && brew install ${{ matrix.shell }}"
+        name: Update formulae and install ${{matrix.shell}} using Homebrew
         if: matrix.setup.os == 'macos'
       - run: |
           if [ -f ~/.bashrc ]; then

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ curl -fsSL https://fnm.vercel.app/install | bash
 
 #### Upgrade
 
-On OSX, it is a simple as `brew upgrade Schniz/tap/fnm`.
+On OSX, it is a simple as `brew upgrade fnm`.
 
 On other operating systems, upgrading `fnm` is almost the same as installing it. To prevent duplication in your shell config file add `--skip-shell` to install command.
 
@@ -62,10 +62,8 @@ curl -fsSL https://fnm.vercel.app/install | bash -s -- --install-dir "./.fnm" --
 
 #### Using Homebrew (OSX)
 
-[This is a custom tap I'm maintaining](https://github.com/Schniz/homebrew-tap), and will be used until fnm will move to the official one.
-
 ```bash
-brew install Schniz/tap/fnm
+brew install fnm
 ```
 
 Then apply the changes the installer prints, to set up your shell profile.


### PR DESCRIPTION
Updated locations which reference the deprecated tap. Homebrew instructions will now relate to the `homebrew/core` formula.

I would have liked to add an automated Homebrew release strategy in this PR as well, but it seems that the current release strategy is done manually (i.e. outside of GitHub Actions (GHA) at least; please correct me if I'm wrong). A new issue outlining an automated strategy for pushes to the main branch done via GHA would definitely help get the ball rolling with this 😉 

Relates to Schniz/homebrew-tap#12.