### PR TITLE
Add `list` alias for `ls`

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,11 @@ Activates `[VERSION]` as the current Node version. If no version provided, it wi
 
 Display currently activated Node version.
 
-### `fnm ls`
+### `fnm list`
 
 Lists the installed Node versions.
 
-### `fnm ls-remote`
+### `fnm list-remote`
 
 Lists the Node versions available to download remotely.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ use structopt::StructOpt;
 #[derive(StructOpt, Debug)]
 pub enum SubCommand {
     /// List all remote Node.js versions
-    #[structopt(name = "ls-remote")]
+    #[structopt(name = "ls-remote", aliases = &["list-remote"])]
     LsRemote(commands::ls_remote::LsRemote),
 
     /// List all locally installed Node.js versions

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,11 +6,11 @@ use structopt::StructOpt;
 #[derive(StructOpt, Debug)]
 pub enum SubCommand {
     /// List all remote Node.js versions
-    #[structopt(name = "ls-remote", aliases = &["list-remote"])]
+    #[structopt(name = "list-remote", aliases = &["ls-remote"])]
     LsRemote(commands::ls_remote::LsRemote),
 
     /// List all locally installed Node.js versions
-    #[structopt(name = "ls", aliases = &["list"])]
+    #[structopt(name = "list", aliases = &["ls"])]
     LsLocal(commands::ls_local::LsLocal),
 
     /// Install a new Node.js version

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,7 +10,7 @@ pub enum SubCommand {
     LsRemote(commands::ls_remote::LsRemote),
 
     /// List all locally installed Node.js versions
-    #[structopt(name = "ls")]
+    #[structopt(name = "ls", aliases = &["list"])]
     LsLocal(commands::ls_local::LsLocal),
 
     /// Install a new Node.js version


### PR DESCRIPTION
In my opinion it would be sensible to add `fnm list` as an alias of `fnm ls`. At least for me, it's the natural command I think of for listing a version manager's installed versions.