### PR TITLE
Switching back to default if no `.node-version` or `.nvmrc` file is present

### DIFF
--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -24,7 +24,7 @@ impl Shell for Bash {
                 __fnmcd () {
                     cd "$@"
                     
-                    if [ -s $(pwd)/.node-version ] || [ -s $(pwd)/.nvmrc ]; then
+                    if [ -s .node-version ] || [ -s .nvmrc ]; then
                         fnm use
                     else
                         fnm use default

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -23,11 +23,11 @@ impl Shell for Bash {
             r#"
                 __fnmcd () {
                     cd "$@"
-
-                    if [[ -f .node-version && .node-version ]]; then
+                    
+                    if [ -s $(pwd)/.node-version ] || [ -s $(pwd)/.nvmrc ]; then
                         fnm use
-                    elif [[ -f .nvmrc && .nvmrc ]]; then
-                        fnm use
+                    else
+                        fnm use default
                     fi
                 }
 


### PR DESCRIPTION
This would be the solution to no. 2 of this #320