### PR TITLE
Run `fnm use` on shell initialization in Bash

### DIFF
--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -21,17 +21,19 @@ impl Shell for Bash {
     fn use_on_cd(&self, _config: &crate::config::FnmConfig) -> String {
         indoc!(
             r#"
-                __fnmcd () {
-                    cd "$@"
-
-                    if [[ -f .node-version && .node-version ]]; then
-                        fnm use
-                    elif [[ -f .nvmrc && .nvmrc ]]; then
+                __fnm_use_if_file_found() {
+                    if [[ -f .node-version || -f .nvmrc ]]; then
                         fnm use
                     fi
                 }
 
+                __fnmcd () {
+                    cd "$@" || return $?
+                    __fnm_use_if_file_found
+                }
+
                 alias cd=__fnmcd
+                __fnm_use_if_file_found
             "#
         )
         .into()

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -23,9 +23,7 @@ impl Shell for Fish {
             r#"
                 function _fnm_autoload_hook --on-variable PWD --description 'Change Node version on directory change'
                     status --is-command-substitution; and return
-                    if test -f .node-version
-                        fnm use
-                    else if test -f .nvmrc
+                    if test -f .node-version -o -f .nvmrc
                         fnm use
                     end
                 end

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -23,9 +23,7 @@ impl Shell for Zsh {
             r#"
                 autoload -U add-zsh-hook
                 _fnm_autoload_hook () {
-                    if [[ -f .node-version && -r .node-version ]]; then
-                        fnm use
-                    elif [[ -f .nvmrc && -r .nvmrc ]]; then
+                    if [[ -f .node-version || -f .nvmrc ]]; then
                         fnm use
                     fi
                 }


### PR DESCRIPTION
This is done in Fish and Zsh already by using their hooks. Bash doesn't does it automatically so this fixes it. Also, it implements what @mirabilos suggested in https://github.com/Schniz/fnm/issues/305#issuecomment-719973203 to make the bash function better.

Fixes #320