### PR TITLE
Escape `cd` calls in Bash's use-on-cd

### DIFF
--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -27,8 +27,8 @@ impl Shell for Bash {
                     fi
                 }
 
-                __fnmcd () {
-                    cd "$@" || return $?
+                __fnmcd() {
+                    \cd "$@" || return $?
                     __fnm_use_if_file_found
                 }
 


### PR DESCRIPTION
This was suggested by @mirabilos 😃