### PR TITLE
Request: Add ARM v6 compatibility

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -43,7 +43,7 @@ set_filename() {
   if [ "$OS" == "Linux" ]; then
     # Based on https://stackoverflow.com/a/45125525
     case "$(uname -m)" in
-      arm | armv7*)
+      arm | armv6* | armv7*)
         FILENAME="fnm-arm32"
         ;;
       aarch* | armv8*)

--- a/.github/workflows/installation_script.yml
+++ b/.github/workflows/installation_script.yml
@@ -16,6 +16,7 @@ jobs:
         docker_image:
           - arm64v8/ubuntu
           - arm32v7/ubuntu
+          - arm32v6/ubuntu
     name: Test against latest release (ARM)
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Hey @Schniz, I'm using quite an old Raspberry Pi that's using an ARM v6 based processor (`armv6l`). I saw that you made your awesome version manager compatible with ARM recently in https://github.com/Schniz/fnm/issues/302. `fnm` isn't (yet) compatible with ARM v6 though, I'm getting the same error as mentioned in #302:

```sh
pi@raspberrypi:~ $ fnm
-bash: /home/pi/.fnm/fnm: cannot execute binary file: Exec format error
```

I haven't set up the full toolchain locally to test it out, I was hoping that my changes would be enough to be able to try an automatic build 😇.