### PR TITLE
Check if $ZDOTDIR exists to find correct path to .zshrc

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -148,7 +148,7 @@ setup_shell() {
   CURRENT_SHELL="$(basename "$SHELL")"
 
   if [ "$CURRENT_SHELL" == "zsh" ]; then
-    CONF_FILE=$HOME/.zshrc
+    CONF_FILE=${ZDOTDIR:-$HOME}/.zshrc
     ensure_containing_dir_exists "$CONF_FILE"
     echo "Installing for Zsh. Appending the following to $CONF_FILE:"
     echo ""


### PR DESCRIPTION
Zsh provides a way to keep all related files in a separate directory by exporting a ZDOTDIR variable, but the install.sh script doesn't check It. 

This is a minor issue, but may lead to some bad first time experience for some users, since the required lines would be added in a .zshrc file that is never sourced.