### PR TITLE
Improvements to the README

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -56,7 +56,7 @@ set_filename() {
     FILENAME="fnm-macos"
     USE_HOMEBREW="false"
     echo "Downloading the latest fnm binary from GitHub..."
-    echo "  Pro tip: it's eaiser to use Homebrew for managing fnm in MacOS."
+    echo "  Pro tip: it's eaiser to use Homebrew for managing fnm in macOS."
     echo "           Remove the \`--force-no-brew\` so it will be easy to upgrade."
   elif [ "$OS" == "Darwin" ]; then
     USE_HOMEBREW="true"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
 name: Rust
 
-on: 
+on:
   pull_request:
   push:
     branches:
@@ -68,7 +68,7 @@ jobs:
 
   build_macos_release:
     runs-on: macOS-latest
-    name: "Release build for MacOS"
+    name: "Release build for macOS"
     steps:
     - uses: hecrj/setup-rust-action@v1
       with:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ curl -fsSL https://fnm.vercel.app/install | bash -s -- --install-dir "./.fnm" --
 
 ### Manually
 
-#### Using Homebrew (macOS)
+#### Using Homebrew (macOS/Linux)
 
 ```sh
 brew install fnm

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 For `bash`, `zsh` and `fish` shells, there's an [automatic installation script](./.ci/install.sh):
 
-```bash
+```sh
 curl -fsSL https://fnm.vercel.app/install | bash
 ```
 
@@ -52,7 +52,7 @@ macOS installations using the installation script are deprecated in favor of the
 
 Example:
 
-```bash
+```sh
 curl -fsSL https://fnm.vercel.app/install | bash -s -- --install-dir "./.fnm" --skip-shell
 ```
 
@@ -60,7 +60,7 @@ curl -fsSL https://fnm.vercel.app/install | bash -s -- --install-dir "./.fnm" --
 
 #### Using Homebrew (macOS)
 
-```bash
+```sh
 brew install fnm
 ```
 
@@ -68,7 +68,7 @@ Then, [set up your shell for fnm](#shell-setup)
 
 #### Using Scoop (Windows)
 
-```bash
+```sh
 scoop install fnm
 ```
 
@@ -76,7 +76,7 @@ Then, [set up your shell for fnm](#shell-setup)
 
 #### Using Cargo (Linux/macOS/Windows)
 
-```bash
+```sh
 cargo install fnm
 ```
 
@@ -92,7 +92,7 @@ Then, [set up your shell for fnm](#shell-setup)
 
 fnm ships its completions with the binary:
 
-```
+```sh
 fnm completions --shell <SHELL>
 ```
 
@@ -149,7 +149,7 @@ fnm env --use-on-cd | Out-String | Invoke-Expression
 
 fnm is also supported but is not entirely covered. [You can set up a startup script](https://superuser.com/a/144348) and append the following line:
 
-```
+```batch
 FOR /f "tokens=*" %i IN ('fnm env --use-on-cd') DO CALL %i
 ```
 
@@ -157,7 +157,7 @@ FOR /f "tokens=*" %i IN ('fnm env --use-on-cd') DO CALL %i
 
 ### Global Options
 
-```
+```sh
 fnm [--shell=fish|bash|zsh] [--node-dist-mirror=URI] [--fnm-dir=DIR] [--log-level=quiet|error|info] <command>
 ```
 
@@ -221,7 +221,7 @@ PRs welcome :tada:
 
 ### Developing:
 
-```
+```sh
 # Install Rust
 git clone https://github.com/Schniz/fnm.git
 cd fnm/
@@ -230,12 +230,12 @@ cargo build
 
 ### Running Binary:
 
-```
+```sh
 cargo run -- --help # Will behave like `fnm --help`
 ```
 
 ### Running Tests:
 
-```
+```sh
 cargo test
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Features
 
-:earth_americas: Cross-platform support (Mac, Windows, Linux)
+:earth_americas: Cross-platform support (macOS, Windows, Linux)
 
 :sparkles: Single file, easy installation, instant startup
 
@@ -22,7 +22,7 @@
 
 ## Installation
 
-### Using a script (MacOS/Linux)
+### Using a script (macOS/Linux)
 
 For `bash`, `zsh` and `fish` shells, there's an [automatic installation script](./.ci/install.sh):
 
@@ -32,7 +32,7 @@ curl -fsSL https://fnm.vercel.app/install | bash
 
 #### Upgrade
 
-On OSX, it is a simple as `brew upgrade fnm`.
+On macOS, it is as simple as `brew upgrade fnm`.
 
 On other operating systems, upgrading `fnm` is almost the same as installing it. To prevent duplication in your shell config file add `--skip-shell` to install command.
 
@@ -48,7 +48,7 @@ Skip appending shell specific loader to shell config file, based on the current 
 
 `--force-install`
 
-MacOS installations using the installation script are deprecated in favor of the Homebrew formula, but this forces the script to install using it anyway.
+macOS installations using the installation script are deprecated in favor of the Homebrew formula, but this forces the script to install using it anyway.
 
 Example:
 
@@ -58,7 +58,7 @@ curl -fsSL https://fnm.vercel.app/install | bash -s -- --install-dir "./.fnm" --
 
 ### Manually
 
-#### Using Homebrew (OSX)
+#### Using Homebrew (macOS)
 
 ```bash
 brew install fnm
@@ -74,7 +74,7 @@ scoop install fnm
 
 Then, [set up your shell for fnm](#shell-setup)
 
-#### Using Cargo (Linux/Mac/Windows)
+#### Using Cargo (Linux/macOS/Windows)
 
 ```bash
 cargo install fnm
@@ -82,7 +82,7 @@ cargo install fnm
 
 Then, [set up your shell for fnm](#shell-setup)
 
-#### Using a release binary (Linux/Mac/Windows)
+#### Using a release binary (Linux/macOS/Windows)
 
 - Download the [latest release binary](https://github.com/Schniz/fnm/releases) for your system
 - Make it available globally on `PATH` environment variable
@@ -143,7 +143,7 @@ fnm env --use-on-cd | Out-String | Invoke-Expression
 ```
 
 - On Windows, the profile is located at `~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1`
-- For Mac/Linux, the profile is located at `~/.config/powershell/Microsoft.PowerShell_profile.ps1`
+- For macOS/Linux, the profile is located at `~/.config/powershell/Microsoft.PowerShell_profile.ps1`
 
 #### Windows Command Prompt aka Batch aka WinCMD
 


### PR DESCRIPTION
- Normalize spelling of "macOS" (in the README and also in other files)
- Cleanup language identifiers for code blocks in the README
- Mention that Homebrew can be used as an installation method on Linux
  This can be confirmed with the following commands:
  ```console
  ❯ docker run --rm -it homebrew/brew
  root@3ccc2529d999:/home/linuxbrew# brew install fnm
  # --- output redacted for conciseness --
  root@3ccc2529d999:/home/linuxbrew# which fnm
  /home/linuxbrew/.linuxbrew/bin/fnm
  root@3ccc2529d999:/home/linuxbrew# fnm --version
  fnm 1.22.8
  ```