### PR TITLE
Chore - Use a tier 1 target for Linux binary

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,12 +96,12 @@ jobs:
       run: |
         sudo chown -R 1000:1000 .
         docker run --rm -v "$(pwd)":/home/rust/src ekidd/rust-musl-builder:stable \
-          cargo build --release
+          cargo build --target x86_64-unknown-linux-gnu --release
         sudo chown -R $(whoami):$(whoami) .
     - uses: actions/upload-artifact@v2
       with:
         name: fnm-linux
-        path: target/x86_64-unknown-linux-musl/release/fnm
+        path: target/x86_64-unknown-linux-gnu/release/fnm
 
   build_static_arm_binary:
     name: "Build ARM binary"


### PR DESCRIPTION
Accordingly to [Rust docs](https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-2), the previous target (`x86_64-unknown-linux-musl`, tier 2) used is not guaranteed to produce a working build.

Fix #371