### PR TITLE
`fnm exec`: Don't require double-dash

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,7 +54,7 @@ pub enum SubCommand {
     ///
     /// Example:
     /// --------
-    /// fnm exec --using=v12.0.0 -- node --version
+    /// fnm exec --using=v12.0.0 node --version
     /// => v12.0.0
     #[structopt(name = "exec")]
     Exec(commands::exec::Exec),


### PR DESCRIPTION
This PR fixes #396, and allows the following:

```sh-session
$ fnm exec node --version # prints the node version
$ fnm exec --using=12 node --version # will print the version of latest installed Node 12
$ fnm exec -- node --version
$ fnm exec --using=12 -- node --version
```

Where before we had to use double-dash (`--`) to use dashed arguments for the commands.

This might be a breaking change if you used fnm like so:

```sh-session
$ fnm exec node --using=12 myfile.js
```

And expected it to pass `--using=12` to `fnm`. I consider this as a bug.

Thanks for @alexeyten for reporting this and suggesting a solution.