### PR TITLE
Call the fnm use-on-cd hook on fish initialization

### DIFF
--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -27,6 +27,8 @@ impl Shell for Fish {
                         fnm use
                     end
                 end
+
+                _fnm_autoload_hook
             "#
         )
         .into()


### PR DESCRIPTION
This fixes #410