### PR TITLE
Improve "version not found" error message

### DIFF
--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -113,7 +113,7 @@ fn should_install_interactively(requested_version: &UserVersion) -> bool {
 
     use std::io::Write;
     let error_message = format!(
-        "Can't find version that matches {}.",
+        "Can't find an installed Node version matching {}.",
         requested_version.to_string().italic()
     );
     eprintln!("{}", error_message.red());


### PR DESCRIPTION
When automatic switching is on, it can be ambiguous where the message is coming from and what it is referring to:

![Screenshot 2021-03-22 at 15 39 39](https://user-images.githubusercontent.com/478237/112016862-fe82ca80-8b24-11eb-9566-c5193167b96d.png)

The messages only become explicit once one answers "yes", which doesn't sound appropriate. This PR makes the error message unambiguous from the get-go.