### PR TITLE
feat: adds `--arch` option to `fnm install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ Installs `[VERSION]`. If no version provided, it will install the version specif
 
 Installs the latest LTS version of Node
 
+#### Flags
+- `--arch ["x64" | "x86" | "arm64" | "armv7l" | "ppc64le" | "ppc64" | "s390x" ]`
+
+Installs binary for the specified processor architecture.
+
 ### `fnm use [VERSION]`
 
 Activates `[VERSION]` as the current Node version. If no version provided, it will activate the version specified in the `.node-version` or `.nvmrc` file located in the current working directory.

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -1,0 +1,80 @@
+use crate::system_info::platform_arch;
+
+#[derive(Clone, Debug)]
+pub enum Arch {
+    X86,
+    X64,
+    Arm64,
+    Armv7l,
+    Ppc64le,
+    Ppc64,
+    S390x,
+}
+
+#[derive(Debug)]
+pub struct ArchError {
+    details: String,
+}
+
+pub fn get_default() -> Arch {
+    match from_str(platform_arch()) {
+        Ok(arch) => arch,
+        Err(e) => panic!(e.details),
+    }
+}
+
+fn from_str(s: &str) -> Result<Arch, ArchError> {
+    match s {
+        "x86" => Ok(Arch::X86),
+        "x64" => Ok(Arch::X64),
+        "arm64" => Ok(Arch::Arm64),
+        "armv7l" => Ok(Arch::Armv7l),
+        "ppc64le" => Ok(Arch::Ppc64le),
+        "ppc64" => Ok(Arch::Ppc64),
+        "s390x" => Ok(Arch::S390x),
+        unknown => Err(ArchError::new(&format!("Unknown Arch: {}", unknown))),
+    }
+}
+
+impl ArchError {
+    fn new(msg: &str) -> ArchError {
+        ArchError {
+            details: msg.to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for ArchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.details)
+    }
+}
+
+impl std::error::Error for ArchError {
+    fn description(&self) -> &str {
+        &self.details
+    }
+}
+
+impl std::str::FromStr for Arch {
+    type Err = ArchError;
+    fn from_str(s: &str) -> Result<Arch, Self::Err> {
+        from_str(s)
+    }
+}
+
+impl std::fmt::Display for Arch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let arch_str = match self {
+            Arch::X86 => String::from("x86"),
+            Arch::X64 => String::from("x64"),
+            Arch::Arm64 => String::from("arm64"),
+            Arch::Armv7l => String::from("armv7l"),
+            Arch::Ppc64le => String::from("ppc64le"),
+            Arch::Ppc64 => String::from("ppc64"),
+            Arch::S390x => String::from("s390x"),
+        };
+
+        write!(f, "{}", arch_str)
+    }
+}

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -1,3 +1,4 @@
+use crate::arch::Arch;
 use crate::archive;
 use crate::archive::{Error as ExtractError, Extract};
 use crate::directory_portal::DirectoryPortal;
@@ -22,7 +23,7 @@ pub enum Error {
     },
     #[snafu(display("The downloaded archive is empty"))]
     TarIsEmpty,
-    #[snafu(display("Can't find version upstream"))]
+    #[snafu(display("Can't find version/arch upstream"))]
     VersionNotFound,
     #[snafu(display("Version already installed at {:?}", path))]
     VersionAlreadyInstalled {
@@ -31,13 +32,12 @@ pub enum Error {
 }
 
 #[cfg(unix)]
-fn filename_for_version(version: &Version) -> String {
-    use crate::system_info::{platform_arch, platform_name};
+fn filename_for_version(version: &Version, arch: &Arch) -> String {
     format!(
         "node-{node_ver}-{platform}-{arch}.tar.xz",
         node_ver = &version,
-        platform = platform_name(),
-        arch = platform_arch(),
+        platform = crate::system_info::platform_name(),
+        arch = &arch,
     )
 }
 
@@ -50,12 +50,12 @@ fn filename_for_version(version: &Version) -> String {
     )
 }
 
-fn download_url(base_url: &Url, version: &Version) -> Url {
+fn download_url(base_url: &Url, version: &Version, arch: &Arch) -> Url {
     Url::parse(&format!(
         "{}/{}/{}",
         base_url.as_str().trim_end_matches('/'),
         version,
-        filename_for_version(version)
+        filename_for_version(version, arch)
     ))
     .unwrap()
 }
@@ -77,6 +77,7 @@ pub fn install_node_dist<P: AsRef<Path>>(
     version: &Version,
     node_dist_mirror: &Url,
     installations_dir: P,
+    arch: &Arch,
 ) -> Result<(), Error> {
     let installation_dir = PathBuf::from(installations_dir.as_ref()).join(version.v_str());
 
@@ -94,7 +95,7 @@ pub fn install_node_dist<P: AsRef<Path>>(
 
     let portal = DirectoryPortal::new_in(&temp_installations_dir, installation_dir);
 
-    let url = download_url(node_dist_mirror, version);
+    let url = download_url(node_dist_mirror, version, arch);
     debug!("Going to call for {}", &url);
     let response = reqwest::blocking::get(url).context(HttpError)?;
 
@@ -167,8 +168,10 @@ mod tests {
 
     fn install_in(path: &Path) -> PathBuf {
         let version = Version::parse("12.0.0").unwrap();
+        let arch = Arch::X64;
         let node_dist_mirror = Url::parse("https://nodejs.org/dist/").unwrap();
-        install_node_dist(&version, &node_dist_mirror, &path).expect("Can't install Node 12");
+        install_node_dist(&version, &node_dist_mirror, &path, &arch)
+            .expect("Can't install Node 12");
 
         let mut location_path = path.join(version.v_str()).join("installation");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod alias;
+mod arch;
 mod archive;
 mod choose_version_for_user_input;
 mod cli;


### PR DESCRIPTION
fnm defaults to downloading the Node architecture that matches the
current system, a good default.

This commits adds an option to override that default where emulating
other architectures is possible and desired, to wit: MacOS 11 is arm64
but is capable of running x86_64 binaries, and developers may desire
running older versions of Node that are unavailble in arm64 form.

works around #402