### PR TITLE
Fix missing list-remote in command doc

### DIFF
--- a/.ci/print-command-docs.js
+++ b/.ci/print-command-docs.js
@@ -110,10 +110,11 @@ async function getCommandHelp(fnmPath, command) {
   const headerIndex = rows.findIndex((x) => x.includes("SUBCOMMANDS"));
   /** @type {string[]} */
   const subcommands = [];
-  for (const row of rows.slice(headerIndex + 1)) {
-    const matched = row.match(/^\s{4}(\w+)/);
-    if (!matched) break;
-    subcommands.push(matched[1]);
+  if (!command) {
+    for (const row of rows.slice(headerIndex + 1)) {
+      const words = row.split(/\s+/);
+      subcommands.push(words[1]);
+    }
   }
   return {
     subcommands,

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+node_modules/
 docs/screen_recording
 /benchmarks/results
 /target

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -309,14 +309,14 @@ OPTIONS:
 
 ```
 
-# `fnm list`
+# `fnm list-remote`
 
 ```
-fnm-list 1.25.0
-List all locally installed Node.js versions
+fnm-list-remote 1.25.0
+List all remote Node.js versions
 
 USAGE:
-    fnm list [OPTIONS]
+    fnm list-remote [OPTIONS]
 
 FLAGS:
     -h, --help       Prints help information


### PR DESCRIPTION
As mentioned in #453, this fixes the generation script instead of just the doc itself.

cc: @Schniz 