### PR TITLE
Include feature for (native) certificates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ description = "Fast and simple Node.js version manager"
 serde = { version = "1.0.126", features = ["derive"] }
 clap = "2.33.3"
 structopt = "0.3.21"
-reqwest = { version = "0.11.3", features = ["blocking", "json", "rustls-tls", "brotli"], default-features = false }
+reqwest = { version = "0.11.3", features = ["blocking", "json", "rustls-tls", "rustls-tls-native-roots", "brotli"], default-features = false }
 serde_json = "1.0.64"
 chrono = { version = "0.4.19", features = ["serde"] }
 tar = "0.4.35"


### PR DESCRIPTION
Addresses https://github.com/Schniz/fnm/issues/314 allowing use of fnm when behind a proxy with certificates.

This adds the `"rustls-tls-native-roots"` [cargo feature](https://docs.rs/reqwest/0.11.3/reqwest/#optional-features) to reqwest. That uses [rustls-native-certs](https://github.com/rustls/rustls-native-certs):
> rustls-native-certs allows rustls to use the platform's native certificate store when operating as a TLS client.

I tested on macOS both with and without proxy mainly doing `cargo run -- list-remote`, and installing node 16, this worked behind proxy. Without proxy I only tested list-remote. Perhaps other commands need to be retested as well.

The [`native-tls`](https://docs.rs/native-tls/0.2.7/native_tls/) feature might also work, I didn't test. They seem to cover similar functionality but maybe it works better on Linux ARM systems.