### PR TITLE
install.sh: print an exit message for missing deps

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -131,6 +131,7 @@ check_dependencies() {
   fi
 
   if [ "$SHOULD_EXIT" = "true" ]; then
+    echo "Not installing fnm due to missing dependencies."
     exit 1
   fi
 }


### PR DESCRIPTION
Just a nicer installation (attempt) experience.

Before:

```console
$ wget -qO - https://fnm.vercel.app/install | bash
Checking dependencies for the installation script...
Checking availability of curl... Missing!
Checking availability of unzip... OK!
$ # ??
```

After:

```console
$ wget -qO - https://fnm.vercel.app/install | bash
Checking dependencies for the installation script...
Checking availability of curl... Missing!
Checking availability of unzip... OK!
Not installing fnm due to missing dependencies.
$
```