### PR TITLE
Invoke fnm use on startup for PowerShell

### DIFF
--- a/src/shell/powershell.rs
+++ b/src/shell/powershell.rs
@@ -19,10 +19,12 @@ impl Shell for PowerShell {
 
     fn use_on_cd(&self, _config: &crate::config::FnmConfig) -> String {
         indoc!(r#"
-            function Set-LocationWithFnm { param($path); Set-Location $path; If ((Test-Path .nvmrc) -Or (Test-Path .node-version)) { & fnm use } }
+            function Set-OnLoad { If ((Test-Path .nvmrc) -Or (Test-Path .node-version)) { & fnm use } }
+            function Set-LocationWithFnm { param($path); Set-Location $path; Set-OnLoad }
             Set-Alias cd_with_fnm Set-LocationWithFnm -Force
             Remove-Item alias:\cd
             New-Alias cd Set-LocationWithFnm
+            Set-OnLoad
         "#).into()
     }
     fn into_structopt_shell(&self) -> clap::Shell {

--- a/src/shell/powershell.rs
+++ b/src/shell/powershell.rs
@@ -19,12 +19,12 @@ impl Shell for PowerShell {
 
     fn use_on_cd(&self, _config: &crate::config::FnmConfig) -> String {
         indoc!(r#"
-            function Set-OnLoad { If ((Test-Path .nvmrc) -Or (Test-Path .node-version)) { & fnm use } }
-            function Set-LocationWithFnm { param($path); Set-Location $path; Set-OnLoad }
+            function Set-FnmOnLoad { If ((Test-Path .nvmrc) -Or (Test-Path .node-version)) { & fnm use } }
+            function Set-LocationWithFnm { param($path); Set-Location $path; Set-FnmOnLoad }
             Set-Alias cd_with_fnm Set-LocationWithFnm -Force
             Remove-Item alias:\cd
             New-Alias cd Set-LocationWithFnm
-            Set-OnLoad
+            Set-FnmOnLoad
         "#).into()
     }
     fn into_structopt_shell(&self) -> clap::Shell {


### PR DESCRIPTION
I believe this should fix the issue and seems to work running it with `cargo run -- env --use-on-cd` as it would be used on the release build.

Fixes #513 