### PR TITLE
More informative log level error message

### DIFF
--- a/src/log_level.rs
+++ b/src/log_level.rs
@@ -44,7 +44,7 @@ impl std::str::FromStr for LogLevel {
             "quiet" => Ok(Self::Quiet),
             "info" | "all" => Ok(Self::Info),
             "error" => Ok(Self::Error),
-            loglevel => Err(format!("I don't know the log level of {:?}", loglevel)),
+            loglevel => Err(format!("Unrecognized log level {:?}. Supported levels are 'quiet', 'info' and 'error'.", loglevel)),
         }
     }
 }

--- a/src/log_level.rs
+++ b/src/log_level.rs
@@ -44,7 +44,10 @@ impl std::str::FromStr for LogLevel {
             "quiet" => Ok(Self::Quiet),
             "info" | "all" => Ok(Self::Info),
             "error" => Ok(Self::Error),
-            loglevel => Err(format!("Unrecognized log level {:?}. Supported levels are 'quiet', 'info' and 'error'.", loglevel)),
+            loglevel => Err(format!(
+                "Unrecognized log level {:?}. Supported levels are 'quiet', 'info' and 'error'.",
+                loglevel
+            )),
         }
     }
 }


### PR DESCRIPTION
Ideally, [the docs](https://github.com/Schniz/fnm/blob/master/docs/commands.md) should mention these as well, and I'd like to include that change in this PR, but I'm not sure how to insert the list into the current documentation format:

        --log-level <log-level>
            The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]

Any ideas, @Schniz? Maybe something like this?

        --log-level <log-level>
            The log level of fnm commands [env: FNM_LOGLEVEL]  [supported: quiet, info, error; default: info]

Or this, to use the [docopt](http://docopt.org/) syntax?

        --log-level (quiet|info|error)
            The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]