### PR TITLE
Windows: Use junctions rather than symlinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,6 +458,7 @@ dependencies = [
  "env_logger",
  "indoc",
  "insta",
+ "junction",
  "log",
  "pretty_assertions",
  "reqwest",
@@ -761,6 +762,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "junction"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be39922b087cecaba4e2d5592dedfc8bda5d4a5a1231f143337cca207950b61d"
+dependencies = [
+ "scopeguard",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,4 @@ embed-resource = "1.6.3"
 
 [target.'cfg(windows)'.dependencies]
 csv = "1.1.6"
+junction = "0.2.0"

--- a/README.md
+++ b/README.md
@@ -139,16 +139,6 @@ fnm env | source
 
 #### PowerShell
 
-Before adding any configuration to your shell, you'd need to enable symlink support for a standard accounts (non-administrator).
-
-You can do it by enabling [Developer Mode](https://docs.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development), or [updating the Local Security Policy](#local-security-policy).
-
-##### Local Security Policy
-
-Open `Local Security Policy` (`secpol.msc`) and go to `Local Policies` -> `User Rights Assignment`, select `Create symbolic links`, add your user to the list and **reboot**.
-
-> Use `whoami` if you are not sure what's your user name.
-
 Add the following to the end of your profile file:
 
 ```powershell

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -8,7 +8,7 @@ pub fn symlink_dir<P: AsRef<Path>, U: AsRef<Path>>(from: P, to: U) -> std::io::R
 
 #[cfg(windows)]
 pub fn symlink_dir<P: AsRef<Path>, U: AsRef<Path>>(from: P, to: U) -> std::io::Result<()> {
-    std::os::windows::fs::symlink_dir(from, to)?;
+    junction::create(from, to)?;
     Ok(())
 }
 


### PR DESCRIPTION
On windows, creating symlinks requires special privileges.

These privileges are typically either assigned by activating windows’s “Developer Mode” or via security policies.

This makes using _fnm_ more difficult for beginners and people on managed machines, where developer mode might not include the right to create symlinks, and local security policies are reset on a regular basis.

NTFS offers an alternative mechanism. Junctions can be **created without special privileges.**

[superuser.com] has some more extensive answers on the differences between directory symlinks and junctions. The relevant difference for fnm is that symlinks can work across network drives, whereas junctions only work locally. This shouldn’t matter for fnm’s functionality.

By switching to directory junctions, fnm becomes easier to work with on windows, especially under circumstances where privileges to create symlinks cannot be assigned permanently.

This change is backwards compatible: Since both directory symlinks and junctions are removed using `std::fs::remove_dir`, an fnm upgrade will keep working with existing setups.

[Directory Junctions]: https://docs.microsoft.com/en-us/windows/win32/fileio/hard-links-and-junctions#junctions
[superuser.com]: https://superuser.com/questions/343074/directory-junction-vs-directory-symbolic-link