### PR TITLE
Add Chocolatey installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ scoop install fnm
 
 Then, [set up your shell for fnm](#shell-setup)
 
+#### Using Chocolatey (Windows)
+
+```sh
+choco install fnm
+```
+
+Then, [set up your shell for fnm](#shell-setup)
+
 #### Using Cargo (Linux/macOS/Windows)
 
 ```sh


### PR DESCRIPTION
`fnm` is now available on Chocolatey. This change updates the readme with instructions for manual installation on Windows using Chocolatey.

The package can be [seen here](https://community.chocolatey.org/packages/fnm) - if you would like any of the details changed, please let me know by opening an issue on the [fnm-chocolatey](https://github.com/CMeeg/fnm-chocolatey) repo.

This PR resolves #378 