### PR TITLE
Show log level options in help and error message

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -23,8 +23,8 @@ OPTIONS:
             The root directory of fnm installations [env: FNM_DIR]
 
         --log-level <log-level>
-            The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]
-
+            The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
+            error]
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
@@ -63,7 +63,9 @@ OPTIONS:
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary [env: FNM_ARCH]
             [default: x64]
         --fnm-dir <base-dir>                     The root directory of fnm installations [env: FNM_DIR]
-        --log-level <log-level>                  The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]
+        --log-level <log-level>
+            The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
+            error]
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
@@ -91,7 +93,9 @@ OPTIONS:
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary [env: FNM_ARCH]
             [default: x64]
         --fnm-dir <base-dir>                     The root directory of fnm installations [env: FNM_DIR]
-        --log-level <log-level>                  The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]
+        --log-level <log-level>
+            The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
+            error]
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
@@ -118,7 +122,9 @@ OPTIONS:
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary [env: FNM_ARCH]
             [default: x64]
         --fnm-dir <base-dir>                     The root directory of fnm installations [env: FNM_DIR]
-        --log-level <log-level>                  The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]
+        --log-level <log-level>
+            The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
+            error]
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
@@ -151,8 +157,8 @@ OPTIONS:
             The root directory of fnm installations [env: FNM_DIR]
 
         --log-level <log-level>
-            The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]
-
+            The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
+            error]
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
@@ -197,8 +203,8 @@ OPTIONS:
             The root directory of fnm installations [env: FNM_DIR]
 
         --log-level <log-level>
-            The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]
-
+            The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
+            error]
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
@@ -237,8 +243,8 @@ OPTIONS:
             The root directory of fnm installations [env: FNM_DIR]
 
         --log-level <log-level>
-            The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]
-
+            The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
+            error]
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
@@ -277,7 +283,9 @@ OPTIONS:
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary [env: FNM_ARCH]
             [default: x64]
         --fnm-dir <base-dir>                     The root directory of fnm installations [env: FNM_DIR]
-        --log-level <log-level>                  The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]
+        --log-level <log-level>
+            The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
+            error]
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
@@ -304,7 +312,9 @@ OPTIONS:
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary [env: FNM_ARCH]
             [default: x64]
         --fnm-dir <base-dir>                     The root directory of fnm installations [env: FNM_DIR]
-        --log-level <log-level>                  The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]
+        --log-level <log-level>
+            The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
+            error]
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
@@ -328,7 +338,9 @@ OPTIONS:
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary [env: FNM_ARCH]
             [default: x64]
         --fnm-dir <base-dir>                     The root directory of fnm installations [env: FNM_DIR]
-        --log-level <log-level>                  The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]
+        --log-level <log-level>
+            The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
+            error]
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
@@ -352,7 +364,9 @@ OPTIONS:
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary [env: FNM_ARCH]
             [default: x64]
         --fnm-dir <base-dir>                     The root directory of fnm installations [env: FNM_DIR]
-        --log-level <log-level>                  The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]
+        --log-level <log-level>
+            The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
+            error]
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
@@ -389,8 +403,8 @@ OPTIONS:
             The root directory of fnm installations [env: FNM_DIR]
 
         --log-level <log-level>
-            The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]
-
+            The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
+            error]
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
@@ -420,7 +434,9 @@ OPTIONS:
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary [env: FNM_ARCH]
             [default: x64]
         --fnm-dir <base-dir>                     The root directory of fnm installations [env: FNM_DIR]
-        --log-level <log-level>                  The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]
+        --log-level <log-level>
+            The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
+            error]
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,7 +42,8 @@ pub struct FnmConfig {
         env = "FNM_LOGLEVEL",
         default_value = "info",
         global = true,
-        hide_env_values = true
+        hide_env_values = true,
+        possible_values = LogLevel::possible_values()
     )]
     log_level: LogLevel,
 

--- a/src/log_level.rs
+++ b/src/log_level.rs
@@ -24,6 +24,10 @@ impl LogLevel {
             Box::from(std::io::sink())
         }
     }
+
+    pub fn possible_values() -> &'static [&'static str; 4] {
+        &["quiet", "info", "all", "error"]
+    }
 }
 
 impl Into<&'static str> for LogLevel {

--- a/src/log_level.rs
+++ b/src/log_level.rs
@@ -41,17 +41,14 @@ impl Into<&'static str> for LogLevel {
 }
 
 impl std::str::FromStr for LogLevel {
-    type Err = String;
+    type Err = &'static str;
 
     fn from_str(s: &str) -> Result<LogLevel, Self::Err> {
         match s {
             "quiet" => Ok(Self::Quiet),
             "info" | "all" => Ok(Self::Info),
             "error" => Ok(Self::Error),
-            loglevel => Err(format!(
-                "Unrecognized log level {:?}. Supported levels are 'quiet', 'info' and 'error'.",
-                loglevel
-            )),
+            _ => Err("Unsupported log level"),
         }
     }
 }


### PR DESCRIPTION
Using [`Arg::possible_values`](https://docs.rs/clap/2.33.3/clap/struct.Arg.html#method.possible_values) to provide more information in error message and help, following the guidance in https://github.com/Schniz/fnm/issues/523

```
--log-level <log-level>
    The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
    error]
```

<img width="627" alt="error" src="https://user-images.githubusercontent.com/30640930/133730660-551d2b5d-a9f9-4b26-ac39-6d8d67b377de.png">


