### PR TITLE
Update Fish shell instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ eval "$(fnm env)"
 create `~/.config/fish/conf.d/fnm.fish` add this line to it:
 
 ```fish
-fnm env | source
+if status is-interactive
+  fnm env | source
+end
 ```
 
 #### PowerShell
@@ -167,7 +169,7 @@ FOR /f "tokens=*" %i IN ('fnm env --use-on-cd') DO CALL %i
 
 #### Usage with Cmder
 
-Usage is very similar to the normal WinCMD install, apart for a few tweaks to allow being called from the cmder startup script. The example **assumes** that the `CMDER_ROOT` environment variable is **set** to the **root directory** of your Cmder installation.  
+Usage is very similar to the normal WinCMD install, apart for a few tweaks to allow being called from the cmder startup script. The example **assumes** that the `CMDER_ROOT` environment variable is **set** to the **root directory** of your Cmder installation.
 Then you can do something like this:
 
 - Make a .cmd file to invoke it


### PR DESCRIPTION
[`status is-interactive`](https://fishshell.com/docs/current/cmds/status.html#status-query-fish-runtime-information) makes sure the user's `fnm` configuration runs only if the shell is connected to a keyboard (the session is interactive) (#356).