### PR TITLE
Revert the change to ureq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,7 +477,6 @@ name = "fnm"
 version = "1.28.1"
 dependencies = [
  "atty",
- "brotli-decompressor",
  "chrono",
  "clap",
  "colored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443ccbb270374a2b1055fc72da40e1f237809cd6bb0e97e66d264cd138473a6"
+dependencies = [
+ "brotli",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +117,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "brotli"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71cb90ade945043d3d53597b2fc359bb063db8ade2bcffe7997351d0756e9d50"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
 name = "brotli-decompressor"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +160,12 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "bzip2"
@@ -183,12 +213,6 @@ dependencies = [
  "time",
  "winapi",
 ]
-
-[[package]]
-name = "chunked_transfer"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clap"
@@ -384,7 +408,7 @@ checksum = "85505eb239fc952b300f29f0556d2d884082a83566768d980278d8faf38c780d"
 dependencies = [
  "cc",
  "vswhom",
- "winreg",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -468,6 +492,7 @@ dependencies = [
  "junction",
  "log",
  "pretty_assertions",
+ "reqwest",
  "semver",
  "serde",
  "serde_json",
@@ -479,11 +504,16 @@ dependencies = [
  "tar",
  "tempfile",
  "test-env-log",
- "ureq",
  "url",
  "xz2",
  "zip",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -493,6 +523,66 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc8cd39e3dbf865f7340dce6a2d401d24fd37c6fe6c4f0ee0de8bfca2252d27"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
+
+[[package]]
+name = "futures-io"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e481354db6b5c353246ccf6a728b0c5511d752c08da7260546fc0933869daa11"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89f17b21645bc4ed773c69af9c9a0effd4a3f1a3876eadd453469f8854e7fdd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "996c6442437b62d21a32cd9906f9c41e7dc1e19a9579843fad948696769305af"
+
+[[package]]
+name = "futures-task"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
+
+[[package]]
+name = "futures-util"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -511,6 +601,25 @@ name = "gimli"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+
+[[package]]
+name = "h2"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "hashbrown"
@@ -537,10 +646,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436ec0091e4f20e655156a30a0df3770fe2900aa301e548e08446ec794b6953c"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+dependencies = [
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "webpki",
+]
 
 [[package]]
 name = "idna"
@@ -596,6 +778,12 @@ checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itoa"
@@ -691,6 +879,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +892,28 @@ checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
+]
+
+[[package]]
+name = "mio"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -802,6 +1018,18 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -986,6 +1214,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d2927ca2f685faf0fc620ac4834690d29e7abb153add10f5812eef20b5e280"
+dependencies = [
+ "async-compression",
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg 0.7.0",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,10 +1274,11 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustls"
-version = "0.20.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5ac6078ca424dc1d3ae2328526a76787fecc7f8011f520e3276730e711fc95"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
+ "base64",
  "log",
  "ring",
  "sct",
@@ -1032,9 +1299,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
-version = "0.7.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring",
  "untrusted",
@@ -1072,6 +1339,18 @@ version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
 dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
  "itoa",
  "ryu",
  "serde",
@@ -1134,6 +1413,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad1d488a557b235fc46dae55512ffbfc429d2482b08b4d9435ab07384ca8aec"
 
 [[package]]
+name = "slab"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+
+[[package]]
 name = "smallvec"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,6 +1444,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1334,6 +1629,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
+name = "tokio"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+
+[[package]]
+name = "tracing"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,24 +1745,6 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "ureq"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c448dcb78ec38c7d59ec61f87f70a98ea19171e06c139357e012ee226fec90"
-dependencies = [
- "base64",
- "chunked_transfer",
- "log",
- "once_cell",
- "rustls",
- "serde",
- "serde_json",
- "url",
- "webpki",
- "webpki-roots",
-]
 
 [[package]]
 name = "url"
@@ -1447,6 +1797,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,6 +1835,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1518,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.22.0"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",
@@ -1528,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c475786c6f47219345717a043a37ec04cb4bc185e28853adcc4fa0a947eba630"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
  "webpki",
 ]
@@ -1565,6 +1937,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4.14"
 env_logger = "0.9.0"
 atty = "0.2.14"
 encoding_rs_io = "0.1.7"
-ureq = { version = "2.3.1", features = ["json"] }
+reqwest = { version = "0.11.4", features = ["blocking", "json", "rustls-tls", "brotli"], default-features = false }
 url = "2.2.2"
 brotli-decompressor = "2.3.2"
 sysinfo = "0.21.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ atty = "0.2.14"
 encoding_rs_io = "0.1.7"
 reqwest = { version = "0.11.4", features = ["blocking", "json", "rustls-tls", "brotli"], default-features = false }
 url = "2.2.2"
-brotli-decompressor = "2.3.2"
 sysinfo = "0.21.1"
 
 [dev-dependencies]

--- a/src/archive/extract.rs
+++ b/src/archive/extract.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 pub enum Error {
     IoError(std::io::Error),
     ZipError(zip::result::ZipError),
-    HttpError(reqwest::Error),
+    HttpError(crate::http::Error),
 }
 
 impl std::fmt::Display for Error {
@@ -32,8 +32,8 @@ impl From<zip::result::ZipError> for Error {
     }
 }
 
-impl From<reqwest::Error> for Error {
-    fn from(err: reqwest::Error) -> Self {
+impl From<crate::http::Error> for Error {
+    fn from(err: crate::http::Error) -> Self {
         Self::HttpError(err)
     }
 }

--- a/src/archive/extract.rs
+++ b/src/archive/extract.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 pub enum Error {
     IoError(std::io::Error),
     ZipError(zip::result::ZipError),
-    HttpError(ureq::Error),
+    HttpError(reqwest::Error),
 }
 
 impl std::fmt::Display for Error {
@@ -32,8 +32,8 @@ impl From<zip::result::ZipError> for Error {
     }
 }
 
-impl From<ureq::Error> for Error {
-    fn from(err: ureq::Error) -> Self {
+impl From<reqwest::Error> for Error {
+    fn from(err: reqwest::Error) -> Self {
         Self::HttpError(err)
     }
 }

--- a/src/archive/zip.rs
+++ b/src/archive/zip.rs
@@ -87,10 +87,9 @@ mod tests {
     #[test_env_log::test]
     fn test_zip_extraction() {
         let temp_dir = tempfile::tempdir().expect("Can't create a temp directory");
-        let response = ureq::get("https://nodejs.org/dist/v12.0.0/node-v12.0.0-win-x64.zip")
-            .call()
-            .expect("Can't make request to Node v12.0.0 zip file")
-            .into_reader();
+        let response =
+            reqwest::blocking::get("https://nodejs.org/dist/v12.0.0/node-v12.0.0-win-x64.zip")
+                .expect("Can't make request to Node v12.0.0 zip file");
         Zip::new(response)
             .extract_into(&temp_dir)
             .expect("Can't unzip files");

--- a/src/archive/zip.rs
+++ b/src/archive/zip.rs
@@ -87,9 +87,8 @@ mod tests {
     #[test_env_log::test]
     fn test_zip_extraction() {
         let temp_dir = tempfile::tempdir().expect("Can't create a temp directory");
-        let response =
-            reqwest::blocking::get("https://nodejs.org/dist/v12.0.0/node-v12.0.0-win-x64.zip")
-                .expect("Can't make request to Node v12.0.0 zip file");
+        let response = crate::http::get("https://nodejs.org/dist/v12.0.0/node-v12.0.0-win-x64.zip")
+            .expect("Can't make request to Node v12.0.0 zip file");
         Zip::new(response)
             .extract_into(&temp_dir)
             .expect("Can't unzip files");

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -144,7 +144,7 @@ pub enum Error {
     CantInferVersion,
     #[snafu(display("Having a hard time listing the remote versions: {}", source))]
     CantListRemoteVersions {
-        source: ureq::Error,
+        source: reqwest::Error,
     },
     #[snafu(display(
         "Can't find a Node version that matches {} in remote",

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -144,7 +144,7 @@ pub enum Error {
     CantInferVersion,
     #[snafu(display("Having a hard time listing the remote versions: {}", source))]
     CantListRemoteVersions {
-        source: reqwest::Error,
+        source: crate::http::Error,
     },
     #[snafu(display(
         "Can't find a Node version that matches {} in remote",

--- a/src/commands/ls_remote.rs
+++ b/src/commands/ls_remote.rs
@@ -26,5 +26,5 @@ impl super::command::Command for LsRemote {
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    HttpError { source: ureq::Error },
+    HttpError { source: reqwest::Error },
 }

--- a/src/commands/ls_remote.rs
+++ b/src/commands/ls_remote.rs
@@ -26,5 +26,5 @@ impl super::command::Command for LsRemote {
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    HttpError { source: reqwest::Error },
+    HttpError { source: crate::http::Error },
 }

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -12,7 +12,7 @@ use url::Url;
 #[derive(Debug, Snafu)]
 pub enum Error {
     HttpError {
-        source: ureq::Error,
+        source: reqwest::Error,
     },
     IoError {
         source: std::io::Error,
@@ -69,9 +69,8 @@ fn download_url(base_url: &Url, version: &Version, arch: &Arch) -> Url {
 
 pub fn extract_archive_into<P: AsRef<Path>>(
     path: P,
-    response: ureq::Response,
+    response: reqwest::blocking::Response,
 ) -> Result<(), Error> {
-    let response = response.into_reader();
     #[cfg(unix)]
     let extractor = archive::TarXz::new(response);
     #[cfg(windows)]
@@ -105,7 +104,7 @@ pub fn install_node_dist<P: AsRef<Path>>(
 
     let url = download_url(node_dist_mirror, version, arch);
     debug!("Going to call for {}", &url);
-    let response = ureq::get(url.as_str()).call().context(HttpError)?;
+    let response = reqwest::blocking::get(url.as_str()).context(HttpError)?;
 
     if response.status() == 404 {
         return Err(Error::VersionNotFound {

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -12,7 +12,7 @@ use url::Url;
 #[derive(Debug, Snafu)]
 pub enum Error {
     HttpError {
-        source: reqwest::Error,
+        source: crate::http::Error,
     },
     IoError {
         source: std::io::Error,
@@ -69,7 +69,7 @@ fn download_url(base_url: &Url, version: &Version, arch: &Arch) -> Url {
 
 pub fn extract_archive_into<P: AsRef<Path>>(
     path: P,
-    response: reqwest::blocking::Response,
+    response: crate::http::Response,
 ) -> Result<(), Error> {
     #[cfg(unix)]
     let extractor = archive::TarXz::new(response);
@@ -104,7 +104,7 @@ pub fn install_node_dist<P: AsRef<Path>>(
 
     let url = download_url(node_dist_mirror, version, arch);
     debug!("Going to call for {}", &url);
-    let response = reqwest::blocking::get(url.as_str()).context(HttpError)?;
+    let response = crate::http::get(url.as_str()).context(HttpError)?;
 
     if response.status() == 404 {
         return Err(Error::VersionNotFound {

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,10 @@
+//! This module is an adapter for HTTP related operations.
+//! In the future, if we want to migrate to a different HTTP library,
+//! we can easily change this facade instead of multiple places in the crate.
+
+pub type Error = reqwest::Error;
+pub type Response = reqwest::blocking::Response;
+
+pub fn get(url: &str) -> Result<Response, Error> {
+    reqwest::blocking::get(url)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod current_version;
 mod directory_portal;
 mod downloader;
 mod fs;
+mod http;
 mod installed_versions;
 mod lts;
 mod path_ext;

--- a/src/remote_node_index.rs
+++ b/src/remote_node_index.rs
@@ -71,9 +71,9 @@ pub struct IndexedNodeVersion {
 /// ```rust
 /// use crate::remote_node_index::list;
 /// ```
-pub fn list(base_url: &Url) -> Result<Vec<IndexedNodeVersion>, reqwest::Error> {
+pub fn list(base_url: &Url) -> Result<Vec<IndexedNodeVersion>, crate::http::Error> {
     let index_json_url = format!("{}/index.json", base_url);
-    let resp = reqwest::blocking::get(&index_json_url)?;
+    let resp = crate::http::get(&index_json_url)?;
     let mut value: Vec<IndexedNodeVersion> = resp.json()?;
     value.sort_by(|a, b| a.version.cmp(&b.version));
     Ok(value)

--- a/src/remote_node_index.rs
+++ b/src/remote_node_index.rs
@@ -1,7 +1,4 @@
-use std::io;
-
 use crate::version::Version;
-use brotli_decompressor::Decompressor;
 use serde::Deserialize;
 use url::Url;
 
@@ -74,31 +71,10 @@ pub struct IndexedNodeVersion {
 /// ```rust
 /// use crate::remote_node_index::list;
 /// ```
-pub fn list(base_url: &Url) -> Result<Vec<IndexedNodeVersion>, ureq::Error> {
+pub fn list(base_url: &Url) -> Result<Vec<IndexedNodeVersion>, reqwest::Error> {
     let index_json_url = format!("{}/index.json", base_url);
-    let resp = ureq::get(&index_json_url)
-        .set("Accept-Encoding", "br")
-        .call()?;
-
-    let brotli_encoded = resp
-        .header("Content-Encoding")
-        .map(|enc| enc.eq_ignore_ascii_case("br"))
-        .unwrap_or_default();
-    let reader = resp.into_reader();
-
-    let value = if brotli_encoded {
-        serde_json::from_reader(Decompressor::new(reader, 0))
-    } else {
-        serde_json::from_reader(reader)
-    };
-
-    let mut value: Vec<IndexedNodeVersion> = value.map_err(|e| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("failed decoding index JSON data: {}", e),
-        )
-    })?;
-
+    let resp = reqwest::blocking::get(&index_json_url)?;
+    let mut value: Vec<IndexedNodeVersion> = resp.json()?;
     value.sort_by(|a, b| a.version.cmp(&b.version));
     Ok(value)
 }


### PR DESCRIPTION
Since our change from [reqwest] to [ureq], we had two regressions:

1. #580 - custom TLS certificate issues
1. #585 - http proxy issues

I have a strong feeling that by reverting the change we might get back these features for free. Yes, binary size will be larger, but these features are more important than a couple of bytes. Too bad that we don't have tests that test it though. I am not really sure how to test both of these features easily.

[reqwest]: https://docs.rs/reqwest
[ureq]: https://docs.rs/ureq
