### PR TITLE
Migrate to Rust 2021 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
  "sysinfo",
  "tar",
  "tempfile",
- "test-env-log",
+ "test-log",
  "url",
  "xz2",
  "zip",
@@ -1554,10 +1554,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "test-env-log"
+name = "test-log"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877189d680101869f65ef94168105d6c188b3a143c13a2d42cf8a09c4c704f8a"
+checksum = "eb78caec569a40f42c078c798c0e35b922d9054ec28e166f0d6ac447563d91a4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,10 @@ sysinfo = "0.22.3"
 [dev-dependencies]
 pretty_assertions = "1.0.0"
 duct = "0.13.5"
-test-env-log = "0.2.8"
 shell-escape = "0.1.5"
 insta = { version = "1.8.0", features = ["backtrace"] }
 serial_test = "0.5.1"
+test-log = "0.2.8"
 
 [build-dependencies]
 embed-resource = "1.6.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fnm"
 version = "1.28.2"
 authors = ["Gal Schlezinger <gal@spitfire.co.il>"]
-edition = "2018"
+edition = "2021"
 build = "build.rs"
 license = "GPL-3.0"
 repository = "https://github.com/Schniz/fnm"

--- a/src/archive/zip.rs
+++ b/src/archive/zip.rs
@@ -84,7 +84,7 @@ impl<R: Read> Extract for Zip<R> {
 mod tests {
     use super::*;
 
-    #[test_env_log::test]
+    #[test_log::test]
     fn test_zip_extraction() {
         let temp_dir = tempfile::tempdir().expect("Can't create a temp directory");
         let response = crate::http::get("https://nodejs.org/dist/v12.0.0/node-v12.0.0-win-x64.zip")

--- a/src/commands/command.rs
+++ b/src/commands/command.rs
@@ -8,7 +8,7 @@ pub trait Command: Sized {
 
     fn handle_error(err: Self::Error, config: &FnmConfig) {
         let err_s = format!("{}", err);
-        outln!(config#Error, "{} {}", "error:".red().bold(), err_s.red());
+        outln!(config, Error, "{} {}", "error:".red().bold(), err_s.red());
         std::process::exit(1);
     }
 

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -50,7 +50,13 @@ impl Command for Env {
 
     fn apply(self, config: &FnmConfig) -> Result<(), Self::Error> {
         if self.multi {
-            outln!(config#Error, "{} {} is deprecated. This is now the default.", "warning:".yellow().bold(), "--multi".italic());
+            outln!(
+                config,
+                Error,
+                "{} {} is deprecated. This is now the default.",
+                "warning:".yellow().bold(),
+                "--multi".italic()
+            );
         }
 
         let shell: Box<dyn Shell> = self.shell.or_else(&infer_shell).context(CantInferShell)?;

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -29,7 +29,13 @@ impl Cmd for Exec {
 
     fn apply(self, config: &FnmConfig) -> Result<(), Self::Error> {
         if self.using_file {
-            outln!(config#Error, "{} {} is deprecated. This is now the default.", "warning:".yellow().bold(), "--using-file".italic());
+            outln!(
+                config,
+                Error,
+                "{} {} is deprecated. This is now the default.",
+                "warning:".yellow().bold(),
+                "--using-file".italic()
+            );
         }
 
         let (binary, arguments) = self.arguments.split_first().context(NoBinaryProvided)?;

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -96,7 +96,13 @@ impl super::command::Command for Install {
         let safe_arch = get_safe_arch(&config.arch, &version);
 
         let version_str = format!("Node {}", &version);
-        outln!(config#Info, "Installing {} ({})", version_str.cyan(), safe_arch.to_string());
+        outln!(
+            config,
+            Info,
+            "Installing {} ({})",
+            version_str.cyan(),
+            safe_arch.to_string()
+        );
 
         match install_node_dist(
             &version,
@@ -105,7 +111,7 @@ impl super::command::Command for Install {
             safe_arch,
         ) {
             Err(err @ DownloaderError::VersionAlreadyInstalled { .. }) => {
-                outln!(config#Error, "{} {}", "warning:".bold().yellow(), err);
+                outln!(config, Error, "{} {}", "warning:".bold().yellow(), err);
             }
             other_err => other_err.context(DownloadError)?,
         };

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -63,12 +63,22 @@ impl Command for Uninstall {
 
         debug!("Removing Node version from {:?}", root_path);
         std::fs::remove_dir_all(root_path).context(CantDeleteNodeVersion)?;
-        outln!(config#Info, "Node version {} was removed successfully", version.v_str().cyan());
+        outln!(
+            config,
+            Info,
+            "Node version {} was removed successfully",
+            version.v_str().cyan()
+        );
 
         for alias in matching_aliases {
             debug!("Removing alias from {:?}", alias.path());
             remove_symlink_dir(alias.path()).context(CantDeleteSymlink)?;
-            outln!(config#Info, "Alias {} was removed successfully", alias.name().cyan());
+            outln!(
+                config,
+                Info,
+                "Alias {} was removed successfully",
+                alias.name().cyan()
+            );
         }
 
         Ok(())

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -38,17 +38,27 @@ impl Command for Use {
             .context(CantInferVersion)?;
 
         let version_path = if let UserVersion::Full(Version::Bypassed) = requested_version {
-            outln!(config#Info, "Bypassing fnm: using {} node", system_version::display_name().cyan());
+            outln!(
+                config,
+                Info,
+                "Bypassing fnm: using {} node",
+                system_version::display_name().cyan()
+            );
             system_version::path()
         } else if let Some(alias_name) = requested_version.alias_name() {
             let alias_path = config.aliases_dir().join(&alias_name);
             let system_path = system_version::path();
             if matches!(fs::shallow_read_symlink(&alias_path), Ok(shallow_path) if shallow_path == system_path)
             {
-                outln!(config#Info, "Bypassing fnm: using {} node", system_version::display_name().cyan());
+                outln!(
+                    config,
+                    Info,
+                    "Bypassing fnm: using {} node",
+                    system_version::display_name().cyan()
+                );
                 system_path
             } else if alias_path.exists() {
-                outln!(config#Info, "Using Node for alias {}", alias_name.cyan());
+                outln!(config, Info, "Using Node for alias {}", alias_name.cyan());
                 alias_path
             } else {
                 install_new_version(requested_version, config, self.install_if_missing)?;
@@ -57,7 +67,7 @@ impl Command for Use {
         } else {
             let current_version = requested_version.to_version(&all_versions, config);
             if let Some(version) = current_version {
-                outln!(config#Info, "Using Node {}", version.to_string().cyan());
+                outln!(config, Info, "Using Node {}", version.to_string().cyan());
                 config
                     .installations_dir()
                     .join(version.to_string())
@@ -156,7 +166,7 @@ fn warn_if_multishell_path_not_in_path_env_var(
     }
 
     outln!(
-        config#Error,
+        config, Error,
         "{} {}\n{}\n{}",
         "warning:".yellow().bold(),
         "The current Node.js path is not on your PATH environment variable.".yellow(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,7 +111,7 @@ impl FnmConfig {
                 });
 
                 outln!(
-                    self#Error,
+                    self, Error,
                     "{}\n  It looks like you have the {} directory on your disk.\n  fnm is migrating its default storage location for application data to {}.\n  You can read more about it here: {}\n",
                     "warning:".yellow().bold(),
                     legacy_str.italic(),

--- a/src/directory_portal.rs
+++ b/src/directory_portal.rs
@@ -52,7 +52,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use tempfile::tempdir;
 
-    #[test_env_log::test]
+    #[test_log::test]
     fn test_portal() {
         let tempdir = tempdir().expect("Can't generate a temp directory");
         let portal = DirectoryPortal::new_in(std::env::temp_dir(), tempdir.path().join("subdir"));

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -140,7 +140,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use tempfile::tempdir;
 
-    #[test_env_log::test]
+    #[test_log::test]
     fn test_installing_node_12() {
         let installations_dir = tempdir().unwrap();
         let node_path = install_in(installations_dir.path()).join("node");
@@ -156,7 +156,7 @@ mod tests {
         assert_eq!(result.trim(), "v12.0.0");
     }
 
-    #[test_env_log::test]
+    #[test_log::test]
     fn test_installing_npm() {
         let installations_dir = tempdir().unwrap();
         let npm_path = install_in(installations_dir.path()).join(if cfg!(windows) {

--- a/src/log_level.rs
+++ b/src/log_level.rs
@@ -52,7 +52,7 @@ impl std::str::FromStr for LogLevel {
 
 #[macro_export]
 macro_rules! outln {
-    ($config:ident#$level:path, $($expr:expr),+) => {{
+    ($config:ident, $level:path, $($expr:expr),+) => {{
         use $crate::log_level::LogLevel::*;
         writeln!($config.log_level().writer_for(&$level), $($expr),+).expect("Can't write output");
     }}


### PR DESCRIPTION
- set 2021
- Change loggin macro to use comma instead of special #
- Use test-log instead of test-env-log
