### PR TITLE
Allow recursive version lookups

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -579,7 +579,7 @@ FLAGS:
         --install-if-missing
             Install the version if it isn't installed yet
 
-        --silent-when-unchanged
+        --silent-if-unchanged
             Don't output a message identifying the version being used if it will not change due to execution of this
             command
     -V, --version

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -28,6 +28,14 @@ OPTIONS:
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
+        --version-file-strategy <version-file-strategy>
+            A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a
+            version, or when `--use-on-cd` is configured on evaluation.
+
+            * `local`: Use the local version of Node defined within the current directory
+
+            * `recursive`: Use the version of Node defined within the current directory and all parent directories [env:
+            FNM_VERSION_FILE_STRATEGY]  [default: local]  [possible values: local, recursive]
 
 SUBCOMMANDS:
     alias          Alias a version to a common name
@@ -55,24 +63,42 @@ USAGE:
     fnm alias [OPTIONS] <to-version> <name>
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help
+            Prints help information
+
+    -V, --version
+            Prints version information
+
 
 OPTIONS:
         --arch <arch>
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary [env: FNM_ARCH]
             [default: x64]
-        --fnm-dir <base-dir>                     The root directory of fnm installations [env: FNM_DIR]
+        --fnm-dir <base-dir>
+            The root directory of fnm installations [env: FNM_DIR]
+
         --log-level <log-level>
             The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
             error]
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
+        --version-file-strategy <version-file-strategy>
+            A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a
+            version, or when `--use-on-cd` is configured on evaluation.
+
+            * `local`: Use the local version of Node defined within the current directory
+
+            * `recursive`: Use the version of Node defined within the current directory and all parent directories [env:
+            FNM_VERSION_FILE_STRATEGY]  [default: local]  [possible values: local, recursive]
 
 ARGS:
     <to-version>
+
+
     <name>
+
+
 ```
 
 # `fnm completions`
@@ -85,14 +111,20 @@ USAGE:
     fnm completions [OPTIONS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help
+            Prints help information
+
+    -V, --version
+            Prints version information
+
 
 OPTIONS:
         --arch <arch>
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary [env: FNM_ARCH]
             [default: x64]
-        --fnm-dir <base-dir>                     The root directory of fnm installations [env: FNM_DIR]
+        --fnm-dir <base-dir>
+            The root directory of fnm installations [env: FNM_DIR]
+
         --log-level <log-level>
             The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
             error]
@@ -102,6 +134,14 @@ OPTIONS:
         --shell <shell>
             The shell syntax to use. Infers when missing [possible values: zsh, bash, fish, powershell, elvish]
 
+        --version-file-strategy <version-file-strategy>
+            A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a
+            version, or when `--use-on-cd` is configured on evaluation.
+
+            * `local`: Use the local version of Node defined within the current directory
+
+            * `recursive`: Use the version of Node defined within the current directory and all parent directories [env:
+            FNM_VERSION_FILE_STRATEGY]  [default: local]  [possible values: local, recursive]
 ```
 
 # `fnm current`
@@ -114,20 +154,34 @@ USAGE:
     fnm current [OPTIONS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help
+            Prints help information
+
+    -V, --version
+            Prints version information
+
 
 OPTIONS:
         --arch <arch>
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary [env: FNM_ARCH]
             [default: x64]
-        --fnm-dir <base-dir>                     The root directory of fnm installations [env: FNM_DIR]
+        --fnm-dir <base-dir>
+            The root directory of fnm installations [env: FNM_DIR]
+
         --log-level <log-level>
             The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
             error]
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
+        --version-file-strategy <version-file-strategy>
+            A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a
+            version, or when `--use-on-cd` is configured on evaluation.
+
+            * `local`: Use the local version of Node defined within the current directory
+
+            * `recursive`: Use the version of Node defined within the current directory and all parent directories [env:
+            FNM_VERSION_FILE_STRATEGY]  [default: local]  [possible values: local, recursive]
 ```
 
 # `fnm default`
@@ -162,6 +216,14 @@ OPTIONS:
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
+        --version-file-strategy <version-file-strategy>
+            A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a
+            version, or when `--use-on-cd` is configured on evaluation.
+
+            * `local`: Use the local version of Node defined within the current directory
+
+            * `recursive`: Use the version of Node defined within the current directory and all parent directories [env:
+            FNM_VERSION_FILE_STRATEGY]  [default: local]  [possible values: local, recursive]
 
 ARGS:
     <version>
@@ -211,6 +273,14 @@ OPTIONS:
         --shell <shell>
             The shell syntax to use. Infers when missing [possible values: bash, zsh, fish, powershell]
 
+        --version-file-strategy <version-file-strategy>
+            A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a
+            version, or when `--use-on-cd` is configured on evaluation.
+
+            * `local`: Use the local version of Node defined within the current directory
+
+            * `recursive`: Use the version of Node defined within the current directory and all parent directories [env:
+            FNM_VERSION_FILE_STRATEGY]  [default: local]  [possible values: local, recursive]
 ```
 
 # `fnm exec`
@@ -251,6 +321,14 @@ OPTIONS:
         --using <version>
             Either an explicit version, or a filename with the version written in it
 
+        --version-file-strategy <version-file-strategy>
+            A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a
+            version, or when `--use-on-cd` is configured on evaluation.
+
+            * `local`: Use the local version of Node defined within the current directory
+
+            * `recursive`: Use the version of Node defined within the current directory and all parent directories [env:
+            FNM_VERSION_FILE_STRATEGY]  [default: local]  [possible values: local, recursive]
 
 ARGS:
     <arguments>...
@@ -274,24 +352,42 @@ USAGE:
     fnm install [FLAGS] [OPTIONS] [version]
 
 FLAGS:
-    -h, --help       Prints help information
-        --lts        Install latest LTS
-    -V, --version    Prints version information
+    -h, --help
+            Prints help information
+
+        --lts
+            Install latest LTS
+
+    -V, --version
+            Prints version information
+
 
 OPTIONS:
         --arch <arch>
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary [env: FNM_ARCH]
             [default: x64]
-        --fnm-dir <base-dir>                     The root directory of fnm installations [env: FNM_DIR]
+        --fnm-dir <base-dir>
+            The root directory of fnm installations [env: FNM_DIR]
+
         --log-level <log-level>
             The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
             error]
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
+        --version-file-strategy <version-file-strategy>
+            A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a
+            version, or when `--use-on-cd` is configured on evaluation.
+
+            * `local`: Use the local version of Node defined within the current directory
+
+            * `recursive`: Use the version of Node defined within the current directory and all parent directories [env:
+            FNM_VERSION_FILE_STRATEGY]  [default: local]  [possible values: local, recursive]
 
 ARGS:
-    <version>    A version string. Can be a partial semver or a LTS version name by the format lts/NAME
+    <version>
+            A version string. Can be a partial semver or a LTS version name by the format lts/NAME
+
 ```
 
 # `fnm list`
@@ -304,20 +400,34 @@ USAGE:
     fnm list [OPTIONS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help
+            Prints help information
+
+    -V, --version
+            Prints version information
+
 
 OPTIONS:
         --arch <arch>
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary [env: FNM_ARCH]
             [default: x64]
-        --fnm-dir <base-dir>                     The root directory of fnm installations [env: FNM_DIR]
+        --fnm-dir <base-dir>
+            The root directory of fnm installations [env: FNM_DIR]
+
         --log-level <log-level>
             The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
             error]
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
+        --version-file-strategy <version-file-strategy>
+            A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a
+            version, or when `--use-on-cd` is configured on evaluation.
+
+            * `local`: Use the local version of Node defined within the current directory
+
+            * `recursive`: Use the version of Node defined within the current directory and all parent directories [env:
+            FNM_VERSION_FILE_STRATEGY]  [default: local]  [possible values: local, recursive]
 ```
 
 # `fnm list-remote`
@@ -330,20 +440,34 @@ USAGE:
     fnm list-remote [OPTIONS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help
+            Prints help information
+
+    -V, --version
+            Prints version information
+
 
 OPTIONS:
         --arch <arch>
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary [env: FNM_ARCH]
             [default: x64]
-        --fnm-dir <base-dir>                     The root directory of fnm installations [env: FNM_DIR]
+        --fnm-dir <base-dir>
+            The root directory of fnm installations [env: FNM_DIR]
+
         --log-level <log-level>
             The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
             error]
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
+        --version-file-strategy <version-file-strategy>
+            A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a
+            version, or when `--use-on-cd` is configured on evaluation.
+
+            * `local`: Use the local version of Node defined within the current directory
+
+            * `recursive`: Use the version of Node defined within the current directory and all parent directories [env:
+            FNM_VERSION_FILE_STRATEGY]  [default: local]  [possible values: local, recursive]
 ```
 
 # `fnm unalias`
@@ -356,23 +480,39 @@ USAGE:
     fnm unalias [OPTIONS] <requested-alias>
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help
+            Prints help information
+
+    -V, --version
+            Prints version information
+
 
 OPTIONS:
         --arch <arch>
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary [env: FNM_ARCH]
             [default: x64]
-        --fnm-dir <base-dir>                     The root directory of fnm installations [env: FNM_DIR]
+        --fnm-dir <base-dir>
+            The root directory of fnm installations [env: FNM_DIR]
+
         --log-level <log-level>
             The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
             error]
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
+        --version-file-strategy <version-file-strategy>
+            A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a
+            version, or when `--use-on-cd` is configured on evaluation.
+
+            * `local`: Use the local version of Node defined within the current directory
+
+            * `recursive`: Use the version of Node defined within the current directory and all parent directories [env:
+            FNM_VERSION_FILE_STRATEGY]  [default: local]  [possible values: local, recursive]
 
 ARGS:
     <requested-alias>
+
+
 ```
 
 # `fnm uninstall`
@@ -408,6 +548,14 @@ OPTIONS:
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
+        --version-file-strategy <version-file-strategy>
+            A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a
+            version, or when `--use-on-cd` is configured on evaluation.
+
+            * `local`: Use the local version of Node defined within the current directory
+
+            * `recursive`: Use the version of Node defined within the current directory and all parent directories [env:
+            FNM_VERSION_FILE_STRATEGY]  [default: local]  [possible values: local, recursive]
 
 ARGS:
     <version>
@@ -425,22 +573,43 @@ USAGE:
     fnm use [FLAGS] [OPTIONS] [version]
 
 FLAGS:
-    -h, --help                  Prints help information
-        --install-if-missing    Install the version if it isn't installed yet
-    -V, --version               Prints version information
+    -h, --help
+            Prints help information
+
+        --install-if-missing
+            Install the version if it isn't installed yet
+
+        --silent-when-unchanged
+            Don't output a message identifying the version being used if it will not change due to execution of this
+            command
+    -V, --version
+            Prints version information
+
 
 OPTIONS:
         --arch <arch>
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary [env: FNM_ARCH]
             [default: x64]
-        --fnm-dir <base-dir>                     The root directory of fnm installations [env: FNM_DIR]
+        --fnm-dir <base-dir>
+            The root directory of fnm installations [env: FNM_DIR]
+
         --log-level <log-level>
             The log level of fnm commands [env: FNM_LOGLEVEL]  [default: info]  [possible values: quiet, info, all,
             error]
         --node-dist-mirror <node-dist-mirror>
             https://nodejs.org/dist/ mirror [env: FNM_NODE_DIST_MIRROR]  [default: https://nodejs.org/dist]
 
+        --version-file-strategy <version-file-strategy>
+            A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a
+            version, or when `--use-on-cd` is configured on evaluation.
+
+            * `local`: Use the local version of Node defined within the current directory
+
+            * `recursive`: Use the version of Node defined within the current directory and all parent directories [env:
+            FNM_VERSION_FILE_STRATEGY]  [default: local]  [possible values: local, recursive]
 
 ARGS:
     <version>
+
+
 ```

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -67,6 +67,13 @@ impl Command for Env {
         );
         println!(
             "{}",
+            shell.set_env_var(
+                "FNM_VERSION_FILE_STRATEGY",
+                config.version_file_strategy().as_str()
+            )
+        );
+        println!(
+            "{}",
             shell.set_env_var("FNM_DIR", config.base_dir_with_default().to_str().unwrap())
         );
         println!(

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -46,7 +46,7 @@ impl Cmd for Exec {
                 let current_dir = std::env::current_dir().unwrap();
                 UserVersionReader::Path(current_dir)
             })
-            .into_user_version(&config)
+            .into_user_version(config)
             .context(CantInferVersion)?;
 
         let applicable_version = choose_version_for_user_input(&version, config)

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -40,7 +40,7 @@ impl Cmd for Exec {
                 let current_dir = std::env::current_dir().unwrap();
                 UserVersionReader::Path(current_dir)
             })
-            .into_user_version()
+            .into_user_version(&config)
             .context(CantInferVersion)?;
 
         let applicable_version = choose_version_for_user_input(&version, config)

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -50,7 +50,7 @@ impl super::command::Command for Install {
 
         let current_version = self
             .version()?
-            .or_else(|| get_user_version_for_directory(current_dir, &config))
+            .or_else(|| get_user_version_for_directory(current_dir, config))
             .context(CantInferVersion)?;
 
         let version = match current_version.clone() {

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -50,7 +50,7 @@ impl super::command::Command for Install {
 
         let current_version = self
             .version()?
-            .or_else(|| get_user_version_for_directory(current_dir))
+            .or_else(|| get_user_version_for_directory(current_dir, &config))
             .context(CantInferVersion)?;
 
         let version = match current_version.clone() {

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -26,7 +26,7 @@ impl Command for Uninstall {
             .version
             .or_else(|| {
                 let current_dir = std::env::current_dir().unwrap();
-                get_user_version_for_directory(current_dir)
+                get_user_version_for_directory(current_dir, &config)
             })
             .context(CantInferVersion)?;
 

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -26,7 +26,7 @@ impl Command for Uninstall {
             .version
             .or_else(|| {
                 let current_dir = std::env::current_dir().unwrap();
-                get_user_version_for_directory(current_dir, &config)
+                get_user_version_for_directory(current_dir, config)
             })
             .context(CantInferVersion)?;
 

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -24,7 +24,7 @@ pub struct Use {
     /// Don't output a message identifying the version being used
     /// if it will not change due to execution of this command
     #[structopt(long)]
-    silent_when_unchanged: bool,
+    silent_if_unchanged: bool,
 }
 
 impl Command for Use {
@@ -89,7 +89,7 @@ impl Command for Use {
             }
         };
 
-        if !self.silent_when_unchanged || will_version_change(&version_path, config) {
+        if !self.silent_if_unchanged || will_version_change(&version_path, config) {
             outln!(config, Info, "{}", message);
         }
 
@@ -129,7 +129,7 @@ fn install_new_version(
     Use {
         version: Some(UserVersionReader::Direct(requested_version)),
         install_if_missing: true,
-        silent_when_unchanged: false,
+        silent_if_unchanged: false,
     }
     .apply(config)?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use crate::arch::Arch;
 use crate::log_level::LogLevel;
 use crate::outln;
 use crate::path_ext::PathExt;
+use crate::version_file_strategy::VersionFileStrategy;
 use colored::Colorize;
 use dirs::{data_dir, home_dir};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -63,6 +64,22 @@ pub struct FnmConfig {
         hide_env_values = true
     )]
     pub arch: Arch,
+
+    /// A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is
+    /// called without a version, or when `--use-on-cd` is configured on evaluation.
+    ///
+    /// * `local`: Use the local version of Node defined within the current directory
+    ///
+    /// * `recursive`: Use the version of Node defined within the current directory and all parent directories
+    #[structopt(
+        long,
+        env = "FNM_VERSION_FILE_STRATEGY",
+        possible_values = VersionFileStrategy::possible_values(),
+        default_value = "local",
+        global = true,
+        hide_env_values = true,
+    )]
+    version_file_strategy: VersionFileStrategy,
 }
 
 impl Default for FnmConfig {
@@ -73,11 +90,16 @@ impl Default for FnmConfig {
             multishell_path: None,
             log_level: LogLevel::Info,
             arch: Arch::default(),
+            version_file_strategy: VersionFileStrategy::default(),
         }
     }
 }
 
 impl FnmConfig {
+    pub fn version_file_strategy(&self) -> &VersionFileStrategy {
+        &self.version_file_strategy
+    }
+
     pub fn multishell_path(&self) -> Option<&std::path::Path> {
         match &self.multishell_path {
             None => None,

--- a/src/default_version.rs
+++ b/src/default_version.rs
@@ -1,0 +1,9 @@
+use crate::config::FnmConfig;
+use crate::version::Version;
+use std::str::FromStr;
+
+pub fn find_default_version(config: &FnmConfig) -> Option<Version> {
+    let version_path = config.default_version_dir().canonicalize().ok()?;
+    let file_name = version_path.parent()?.file_name()?;
+    Version::from_str(file_name.to_str()?).ok()?.into()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ mod version_files;
 
 #[macro_use]
 mod log_level;
+mod default_version;
 
 fn main() {
     env_logger::init();

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod system_version;
 mod user_version;
 mod user_version_reader;
 mod version;
+mod version_file_strategy;
 mod version_files;
 
 #[macro_use]

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -25,11 +25,11 @@ impl Shell for Bash {
             VersionFileStrategy::Local => indoc!(
                 r#"
                     if [[ -f .node-version || -f .nvmrc ]]; then
-                        fnm use --silent-when-unchanged
+                        fnm use --silent-if-unchanged
                     fi
                 "#
             ),
-            VersionFileStrategy::Recursive => r#"fnm use --silent-when-unchanged"#,
+            VersionFileStrategy::Recursive => r#"fnm use --silent-if-unchanged"#,
         };
         formatdoc!(
             r#"

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -1,5 +1,7 @@
+use crate::version_file_strategy::VersionFileStrategy;
+
 use super::shell::Shell;
-use indoc::indoc;
+use indoc::{formatdoc, indoc};
 use std::path::Path;
 
 #[derive(Debug)]
@@ -18,19 +20,27 @@ impl Shell for Fish {
         format!("set -gx {name} {value:?};", name = name, value = value)
     }
 
-    fn use_on_cd(&self, _config: &crate::config::FnmConfig) -> String {
-        indoc!(
-            r#"
-                function _fnm_autoload_hook --on-variable PWD --description 'Change Node version on directory change'
-                    status --is-command-substitution; and return
+    fn use_on_cd(&self, config: &crate::config::FnmConfig) -> String {
+        let autoload_hook = match config.version_file_strategy() {
+            VersionFileStrategy::Local => indoc!(
+                r#"
                     if test -f .node-version -o -f .nvmrc
                         fnm use
                     end
+                "#
+            ),
+            VersionFileStrategy::Recursive => r#"fnm use --silent-when-unchanged"#,
+        };
+        formatdoc!(
+            r#"
+                function _fnm_autoload_hook --on-variable PWD --description 'Change Node version on directory change'
+                    status --is-command-substitution; and return
+                    {autoload_hook}
                 end
 
                 _fnm_autoload_hook
-            "#
+            "#,
+            autoload_hook = autoload_hook
         )
-        .into()
     }
 }

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -25,11 +25,11 @@ impl Shell for Fish {
             VersionFileStrategy::Local => indoc!(
                 r#"
                     if test -f .node-version -o -f .nvmrc
-                        fnm use
+                        fnm use --silent-if-unchanged
                     end
                 "#
             ),
-            VersionFileStrategy::Recursive => r#"fnm use --silent-when-unchanged"#,
+            VersionFileStrategy::Recursive => r#"fnm use --silent-if-unchanged"#,
         };
         formatdoc!(
             r#"

--- a/src/shell/powershell.rs
+++ b/src/shell/powershell.rs
@@ -24,10 +24,10 @@ impl Shell for PowerShell {
         let autoload_hook = match config.version_file_strategy() {
             VersionFileStrategy::Local => indoc!(
                 r#"
-                    If ((Test-Path .nvmrc) -Or (Test-Path .node-version)) { & fnm use --silent-when-unchanged }
+                    If ((Test-Path .nvmrc) -Or (Test-Path .node-version)) { & fnm use --silent-if-unchanged }
                 "#
             ),
-            VersionFileStrategy::Recursive => r#"fnm use --silent-when-unchanged"#,
+            VersionFileStrategy::Recursive => r#"fnm use --silent-if-unchanged"#,
         };
         formatdoc!(
             r#"

--- a/src/shell/windows_cmd/cd.cmd
+++ b/src/shell/windows_cmd/cd.cmd
@@ -1,10 +1,14 @@
 @echo off
 cd %1
-if exist .nvmrc (
-    fnm use
+if "%FNM_VERSION_FILE_STRATEGY%" == "recursive" (
+  fnm use --silent-when-unchanged
 ) else (
+  if exist .nvmrc (
+    fnm use --silent-when-unchanged
+  ) else (
     if exist .node-version (
-        fnm use
+      fnm use --silent-when-unchanged
     )
+  )
 )
 @echo on

--- a/src/shell/windows_cmd/cd.cmd
+++ b/src/shell/windows_cmd/cd.cmd
@@ -1,13 +1,13 @@
 @echo off
 cd %1
 if "%FNM_VERSION_FILE_STRATEGY%" == "recursive" (
-  fnm use --silent-when-unchanged
+  fnm use --silent-if-unchanged
 ) else (
   if exist .nvmrc (
-    fnm use --silent-when-unchanged
+    fnm use --silent-if-unchanged
   ) else (
     if exist .node-version (
-      fnm use --silent-when-unchanged
+      fnm use --silent-if-unchanged
     )
   )
 )

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -29,11 +29,11 @@ impl Shell for Zsh {
             VersionFileStrategy::Local => indoc!(
                 r#"
                     if [[ -f .node-version || -f .nvmrc ]]; then
-                        fnm use --silent-when-unchanged
+                        fnm use --silent-if-unchanged
                     fi
                 "#
             ),
-            VersionFileStrategy::Recursive => r#"fnm use --silent-when-unchanged"#,
+            VersionFileStrategy::Recursive => r#"fnm use --silent-if-unchanged"#,
         };
         formatdoc!(
             r#"

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -1,5 +1,7 @@
+use crate::version_file_strategy::VersionFileStrategy;
+
 use super::shell::Shell;
-use indoc::indoc;
+use indoc::{formatdoc, indoc};
 use std::path::Path;
 
 #[derive(Debug)]
@@ -22,20 +24,28 @@ impl Shell for Zsh {
         Some("rehash".to_string())
     }
 
-    fn use_on_cd(&self, _config: &crate::config::FnmConfig) -> String {
-        indoc!(
+    fn use_on_cd(&self, config: &crate::config::FnmConfig) -> String {
+        let autoload_hook = match config.version_file_strategy() {
+            VersionFileStrategy::Local => indoc!(
+                r#"
+                    if [[ -f .node-version || -f .nvmrc ]]; then
+                        fnm use --silent-when-unchanged
+                    fi
+                "#
+            ),
+            VersionFileStrategy::Recursive => r#"fnm use --silent-when-unchanged"#,
+        };
+        formatdoc!(
             r#"
                 autoload -U add-zsh-hook
-                _fnm_autoload_hook () {
-                    if [[ -f .node-version || -f .nvmrc ]]; then
-                        fnm use
-                    fi
-                }
+                _fnm_autoload_hook () {{
+                    {autoload_hook}
+                }}
 
                 add-zsh-hook chpwd _fnm_autoload_hook \
                     && _fnm_autoload_hook
-            "#
+            "#,
+            autoload_hook = autoload_hook
         )
-        .into()
     }
 }

--- a/src/user_version_reader.rs
+++ b/src/user_version_reader.rs
@@ -1,3 +1,4 @@
+use crate::config::FnmConfig;
 use crate::user_version::UserVersion;
 use crate::version_files::{get_user_version_for_directory, get_user_version_for_file};
 use std::path::PathBuf;
@@ -10,11 +11,11 @@ pub enum UserVersionReader {
 }
 
 impl UserVersionReader {
-    pub fn into_user_version(self) -> Option<UserVersion> {
+    pub fn into_user_version(self, config: &FnmConfig) -> Option<UserVersion> {
         match self {
             Self::Direct(uv) => Some(uv),
             Self::Path(pathbuf) if pathbuf.is_file() => get_user_version_for_file(&pathbuf),
-            Self::Path(pathbuf) => get_user_version_for_directory(&pathbuf),
+            Self::Path(pathbuf) => get_user_version_for_directory(&pathbuf, &config),
         }
     }
 }
@@ -47,7 +48,8 @@ mod tests {
         write!(file, "14").unwrap();
         let pathbuf = file.path().to_path_buf();
 
-        let user_version = UserVersionReader::Path(pathbuf).into_user_version();
+        let user_version =
+            UserVersionReader::Path(pathbuf).into_user_version(&FnmConfig::default());
         assert_eq!(user_version, Some(UserVersion::OnlyMajor(14)));
     }
 
@@ -58,14 +60,15 @@ mod tests {
         std::fs::write(node_version_path, "14").unwrap();
         let pathbuf = directory.path().to_path_buf();
 
-        let user_version = UserVersionReader::Path(pathbuf).into_user_version();
+        let user_version =
+            UserVersionReader::Path(pathbuf).into_user_version(&FnmConfig::default());
         assert_eq!(user_version, Some(UserVersion::OnlyMajor(14)));
     }
 
     #[test]
     fn test_direct_to_version() {
-        let user_version =
-            UserVersionReader::Direct(UserVersion::OnlyMajor(14)).into_user_version();
+        let user_version = UserVersionReader::Direct(UserVersion::OnlyMajor(14))
+            .into_user_version(&FnmConfig::default());
         assert_eq!(user_version, Some(UserVersion::OnlyMajor(14)));
     }
 

--- a/src/user_version_reader.rs
+++ b/src/user_version_reader.rs
@@ -15,7 +15,7 @@ impl UserVersionReader {
         match self {
             Self::Direct(uv) => Some(uv),
             Self::Path(pathbuf) if pathbuf.is_file() => get_user_version_for_file(&pathbuf),
-            Self::Path(pathbuf) => get_user_version_for_directory(&pathbuf, &config),
+            Self::Path(pathbuf) => get_user_version_for_directory(&pathbuf, config),
         }
     }
 }

--- a/src/version_file_strategy.rs
+++ b/src/version_file_strategy.rs
@@ -32,7 +32,10 @@ impl FromStr for VersionFileStrategy {
         match s {
             "local" => Ok(VersionFileStrategy::Local),
             "recursive" => Ok(VersionFileStrategy::Recursive),
-            _ => Err(format!("Invalid strategy: {}. Expected one of: local, recursive", s)),
+            _ => Err(format!(
+                "Invalid strategy: {}. Expected one of: local, recursive",
+                s
+            )),
         }
     }
 }

--- a/src/version_file_strategy.rs
+++ b/src/version_file_strategy.rs
@@ -32,7 +32,7 @@ impl FromStr for VersionFileStrategy {
         match s {
             "local" => Ok(VersionFileStrategy::Local),
             "recursive" => Ok(VersionFileStrategy::Recursive),
-            _ => Err(format!("Invalid strategy: {}. Expected one of: local, recursive", s).into()),
+            _ => Err(format!("Invalid strategy: {}. Expected one of: local, recursive", s)),
         }
     }
 }

--- a/src/version_file_strategy.rs
+++ b/src/version_file_strategy.rs
@@ -1,0 +1,38 @@
+use std::str::FromStr;
+
+#[derive(Debug)]
+pub enum VersionFileStrategy {
+    Local,
+    Recursive,
+}
+
+impl VersionFileStrategy {
+    pub fn possible_values() -> &'static [&'static str] {
+        &["local", "recursive"]
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            VersionFileStrategy::Local => "local",
+            VersionFileStrategy::Recursive => "recursive",
+        }
+    }
+}
+
+impl Default for VersionFileStrategy {
+    fn default() -> Self {
+        VersionFileStrategy::Local
+    }
+}
+
+impl FromStr for VersionFileStrategy {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "local" => Ok(VersionFileStrategy::Local),
+            "recursive" => Ok(VersionFileStrategy::Recursive),
+            _ => Err(format!("Invalid strategy: {}. Expected one of: local, recursive", s).into()),
+        }
+    }
+}

--- a/src/version_files.rs
+++ b/src/version_files.rs
@@ -18,6 +18,7 @@ pub fn get_user_version_for_directory(
         VersionFileStrategy::Local => get_user_version_for_single_directory(path),
         VersionFileStrategy::Recursive => {
             get_user_version_for_directory_recursive(path).or_else(|| {
+                info!("Did not find anything recursively. Falling back to default alias.");
                 default_version::find_default_version(&config).map(|v| UserVersion::Full(v))
             })
         }

--- a/src/version_files.rs
+++ b/src/version_files.rs
@@ -19,7 +19,7 @@ pub fn get_user_version_for_directory(
         VersionFileStrategy::Recursive => {
             get_user_version_for_directory_recursive(path).or_else(|| {
                 info!("Did not find anything recursively. Falling back to default alias.");
-                default_version::find_default_version(&config).map(|v| UserVersion::Full(v))
+                default_version::find_default_version(config).map(UserVersion::Full)
             })
         }
     }

--- a/src/version_files.rs
+++ b/src/version_files.rs
@@ -1,4 +1,5 @@
 use crate::config::FnmConfig;
+use crate::default_version;
 use crate::user_version::UserVersion;
 use crate::version_file_strategy::VersionFileStrategy;
 use encoding_rs_io::DecodeReaderBytes;
@@ -15,7 +16,11 @@ pub fn get_user_version_for_directory(
 ) -> Option<UserVersion> {
     match config.version_file_strategy() {
         VersionFileStrategy::Local => get_user_version_for_single_directory(path),
-        VersionFileStrategy::Recursive => get_user_version_for_directory_recursive(path),
+        VersionFileStrategy::Recursive => {
+            get_user_version_for_directory_recursive(path).or_else(|| {
+                default_version::find_default_version(&config).map(|v| UserVersion::Full(v))
+            })
+        }
     }
 }
 


### PR DESCRIPTION
Adding the ability to provide `--version-file-strategy=recursive` on
both `fnm env` and on each command can allow us to support recursive
resolutions of the Node versions.

This makes the default Node version as easy as:

```bash
echo "16" > ~/.node-version
```

(assuming your code lives inside your home directory) and fixes #442, if
becomes the default.

---

This fixes #144 which is a very old issue :smiley:
https://github.com/Schniz/fnm/issues/144#issuecomment-770798955

---

This code is under a feature toggle, so we can merge it and consider whether we want to use it eventually.