### PR TITLE
Don't warn on `~/.fnm` yet

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,8 @@
 use crate::arch::Arch;
 use crate::log_level::LogLevel;
-use crate::outln;
 use crate::path_ext::PathExt;
 use crate::version_file_strategy::VersionFileStrategy;
-use colored::Colorize;
 use dirs::{data_dir, home_dir};
-use std::sync::atomic::{AtomicBool, Ordering};
 use structopt::StructOpt;
 use url::Url;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,8 +9,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use structopt::StructOpt;
 use url::Url;
 
-static HAS_WARNED_DEPRECATED_BASE_DIR: AtomicBool = AtomicBool::new(false);
-
 #[derive(StructOpt, Debug)]
 pub struct FnmConfig {
     /// https://nodejs.org/dist/ mirror
@@ -124,24 +122,6 @@ impl FnmConfig {
         let modern = data_dir().map(|dir| dir.join("fnm"));
 
         if let Some(dir) = legacy {
-            if !HAS_WARNED_DEPRECATED_BASE_DIR.load(Ordering::SeqCst) {
-                HAS_WARNED_DEPRECATED_BASE_DIR.store(true, Ordering::SeqCst);
-
-                let legacy_str = dir.display().to_string();
-                let modern_str = modern.map_or("$XDG_DATA_HOME/fnm".to_string(), |path| {
-                    path.display().to_string()
-                });
-
-                outln!(
-                    self, Error,
-                    "{}\n  It looks like you have the {} directory on your disk.\n  fnm is migrating its default storage location for application data to {}.\n  You can read more about it here: {}\n",
-                    "warning:".yellow().bold(),
-                    legacy_str.italic(),
-                    modern_str.italic(),
-                    "https://github.com/schniz/fnm/issues/357".italic()
-                );
-            }
-
             return dir;
         }
 


### PR DESCRIPTION
As mentioned in https://github.com/Schniz/fnm/issues/357#issuecomment-1002106398,
we still install into ~/.fnm in the installation scripts. So in order to
not show warning on new installations, we need to defer the warning
until we have changed the installation script.

This means that we will support the new path :)


(this will be reverted in the near future)