### PR TITLE
Use on cd by default

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -155,12 +155,12 @@ setup_shell() {
     echo ""
     echo '  # fnm'
     echo '  export PATH='"$INSTALL_DIR"':$PATH'
-    echo '  eval "`fnm env`"'
+    echo '  eval "`fnm env --use-on-cd`"'
 
     echo '' >>$CONF_FILE
     echo '# fnm' >>$CONF_FILE
     echo 'export PATH='$INSTALL_DIR':$PATH' >>$CONF_FILE
-    echo 'eval "`fnm env`"' >>$CONF_FILE
+    echo 'eval "`fnm env --use-on-cd`"' >>$CONF_FILE
 
   elif [ "$CURRENT_SHELL" = "fish" ]; then
     CONF_FILE=$HOME/.config/fish/conf.d/fnm.fish
@@ -169,11 +169,11 @@ setup_shell() {
     echo ""
     echo '  # fnm'
     echo '  set PATH '"$INSTALL_DIR"' $PATH'
-    echo '  fnm env | source'
+    echo '  fnm env --use-on-cd | source'
 
     echo '# fnm' >>$CONF_FILE
     echo 'set PATH '"$INSTALL_DIR"' $PATH' >>$CONF_FILE
-    echo 'fnm env | source' >>$CONF_FILE
+    echo 'fnm env --use-on-cd | source' >>$CONF_FILE
 
   elif [ "$CURRENT_SHELL" = "bash" ]; then
     if [ "$OS" = "Darwin" ]; then
@@ -186,12 +186,12 @@ setup_shell() {
     echo ""
     echo '  # fnm'
     echo '  export PATH='"$INSTALL_DIR"':$PATH'
-    echo '  eval "`fnm env`"'
+    echo '  eval "`fnm env --use-on-cd`"'
 
     echo '' >>$CONF_FILE
     echo '# fnm' >>$CONF_FILE
     echo 'export PATH='"$INSTALL_DIR"':$PATH' >>$CONF_FILE
-    echo 'eval "`fnm env`"' >>$CONF_FILE
+    echo 'eval "`fnm env --use-on-cd`"' >>$CONF_FILE
 
   else
     echo "Could not infer shell type. Please set up manually."

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -155,12 +155,12 @@ setup_shell() {
     echo ""
     echo '  # fnm'
     echo '  export PATH='"$INSTALL_DIR"':$PATH'
-    echo '  eval "`fnm env --use-on-cd`"'
+    echo '  eval "`fnm env`"'
 
     echo '' >>$CONF_FILE
     echo '# fnm' >>$CONF_FILE
     echo 'export PATH='$INSTALL_DIR':$PATH' >>$CONF_FILE
-    echo 'eval "`fnm env --use-on-cd`"' >>$CONF_FILE
+    echo 'eval "`fnm env`"' >>$CONF_FILE
 
   elif [ "$CURRENT_SHELL" = "fish" ]; then
     CONF_FILE=$HOME/.config/fish/conf.d/fnm.fish
@@ -169,11 +169,11 @@ setup_shell() {
     echo ""
     echo '  # fnm'
     echo '  set PATH '"$INSTALL_DIR"' $PATH'
-    echo '  fnm env --use-on-cd | source'
+    echo '  fnm env | source'
 
     echo '# fnm' >>$CONF_FILE
     echo 'set PATH '"$INSTALL_DIR"' $PATH' >>$CONF_FILE
-    echo 'fnm env --use-on-cd | source' >>$CONF_FILE
+    echo 'fnm env | source' >>$CONF_FILE
 
   elif [ "$CURRENT_SHELL" = "bash" ]; then
     if [ "$OS" = "Darwin" ]; then
@@ -186,12 +186,12 @@ setup_shell() {
     echo ""
     echo '  # fnm'
     echo '  export PATH='"$INSTALL_DIR"':$PATH'
-    echo '  eval "`fnm env --use-on-cd`"'
+    echo '  eval "`fnm env`"'
 
     echo '' >>$CONF_FILE
     echo '# fnm' >>$CONF_FILE
     echo 'export PATH='"$INSTALL_DIR"':$PATH' >>$CONF_FILE
-    echo 'eval "`fnm env --use-on-cd`"' >>$CONF_FILE
+    echo 'eval "`fnm env`"' >>$CONF_FILE
 
   else
     echo "Could not infer shell type. Please set up manually."

--- a/README.md
+++ b/README.md
@@ -118,12 +118,14 @@ Please follow your shell instructions to install them.
 
 ### Shell Setup
 
-fnm needs to run some shell commands before you can start using it.
-This is done by evaluating the output of `fnm env`. Check out the following guides for the shell you use:
+Environment variables need to be setup before you can start using fnm.
+This is done by evaluating the output of `fnm env`.
+To automatically run `fnm use` when a directory contains a `.node-version` or `.nvmrc` file, add the `--use-on-cd` option to your shell setup.
+Check out the following guides for the shell you use:
 
 #### Bash
 
-add the following to your `.bashrc` profile:
+Add the following to your `.bashrc` profile:
 
 ```bash
 eval "$(fnm env --use-on-cd)"
@@ -131,7 +133,7 @@ eval "$(fnm env --use-on-cd)"
 
 #### Zsh
 
-add the following to your `.zshrc` profile:
+Add the following to your `.zshrc` profile:
 
 ```zsh
 eval "$(fnm env --use-on-cd)"
@@ -139,7 +141,7 @@ eval "$(fnm env --use-on-cd)"
 
 #### Fish shell
 
-create `~/.config/fish/conf.d/fnm.fish` add this line to it:
+Create `~/.config/fish/conf.d/fnm.fish` add this line to it:
 
 ```fish
 fnm env --use-on-cd | source

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ eval "$(fnm env --use-on-cd)"
 add the following to your `.zshrc` profile:
 
 ```zsh
-eval "$(fnm env)"
+eval "$(fnm env --use-on-cd)"
 ```
 
 #### Fish shell
@@ -142,7 +142,7 @@ eval "$(fnm env)"
 create `~/.config/fish/conf.d/fnm.fish` add this line to it:
 
 ```fish
-fnm env | source
+fnm env --use-on-cd | source
 ```
 
 #### PowerShell
@@ -167,7 +167,7 @@ FOR /f "tokens=*" %i IN ('fnm env --use-on-cd') DO CALL %i
 
 #### Usage with Cmder
 
-Usage is very similar to the normal WinCMD install, apart for a few tweaks to allow being called from the cmder startup script. The example **assumes** that the `CMDER_ROOT` environment variable is **set** to the **root directory** of your Cmder installation.  
+Usage is very similar to the normal WinCMD install, apart for a few tweaks to allow being called from the cmder startup script. The example **assumes** that the `CMDER_ROOT` environment variable is **set** to the **root directory** of your Cmder installation.
 Then you can do something like this:
 
 - Make a .cmd file to invoke it

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ This is done by evaluating the output of `fnm env`. Check out the following guid
 add the following to your `.bashrc` profile:
 
 ```bash
-eval "$(fnm env)"
+eval "$(fnm env --use-on-cd)"
 ```
 
 #### Zsh


### PR DESCRIPTION
I noticed that there is no instructions to get fnm to autoswitch envs when navigating to a directory and tinkered a while before I found the option in the Powershell section (obviously autocomplete isn't much help either).

Could we add the `--use-on-cd` flag to all the default instructions?

I just added the flag to bash because I tested it and it worked.