### PR TITLE
[Documentation] Adds Additional info regarding .node-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ Please follow your shell instructions to install them.
 Environment variables need to be setup before you can start using fnm.
 This is done by evaluating the output of `fnm env`.
 To automatically run `fnm use` when a directory contains a `.node-version` or `.nvmrc` file, add the `--use-on-cd` option to your shell setup.
+
+Adding a `.node-version` to your project is as simple as:
+```bash
+$ node --version
+v14.18.3
+$ node --version > .node-version
+```
+
 Check out the following guides for the shell you use:
 
 #### Bash


### PR DESCRIPTION
### Why

I felt this info will enable the repo to have all the relevant information for what to be done in order to make `fnm` set the node version automatically (apart from adding `--use-on-cd` to eval statement)

For new users and users who are not familiar of `.node-version`