### PR TITLE
Use local cache directory instead of temp directory for symlinks

### DIFF
--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -6,6 +6,7 @@ use crate::path_ext::PathExt;
 use crate::shell::{infer_shell, Shell, AVAILABLE_SHELLS};
 use colored::Colorize;
 use std::fmt::Debug;
+use std::path::PathBuf;
 use thiserror::Error;
 
 #[derive(clap::Parser, Debug, Default)]
@@ -30,10 +31,16 @@ fn generate_symlink_path() -> String {
     )
 }
 
+fn symlink_base_dir() -> PathBuf {
+    match dirs::cache_dir() {
+        Some(cache_dir) => cache_dir.join("fnm").join("multishells"),
+        None => std::env::temp_dir().join("fnm_multishells"),
+    }
+    .ensure_exists_silently()
+}
+
 fn make_symlink(config: &FnmConfig) -> std::path::PathBuf {
-    let base_dir = std::env::temp_dir()
-        .join("fnm_multishells")
-        .ensure_exists_silently();
+    let base_dir = symlink_base_dir();
     let mut temp_dir = base_dir.join(generate_symlink_path());
 
     while temp_dir.exists() {

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -32,11 +32,7 @@ fn generate_symlink_path() -> String {
 }
 
 fn symlink_base_dir() -> PathBuf {
-    match dirs::cache_dir() {
-        Some(cache_dir) => cache_dir.join("fnm").join("multishells"),
-        None => std::env::temp_dir().join("fnm_multishells"),
-    }
-    .ensure_exists_silently()
+    crate::directories::multishell_storage().ensure_exists_silently()
 }
 
 fn make_symlink(config: &FnmConfig) -> std::path::PathBuf {

--- a/src/directories.rs
+++ b/src/directories.rs
@@ -1,0 +1,26 @@
+use std::path::PathBuf;
+
+fn xdg_dir(env: &str) -> Option<PathBuf> {
+    let env_var = std::env::var(env).ok()?;
+    Some(PathBuf::from(env_var))
+}
+
+fn state_dir() -> Option<PathBuf> {
+    xdg_dir("XDG_STATE_HOME").or_else(|| dirs::state_dir())
+}
+
+fn cache_dir() -> Option<PathBuf> {
+    xdg_dir("XDG_CACHE_HOME").or_else(|| dirs::cache_dir())
+}
+
+fn runtime_dir() -> Option<PathBuf> {
+    xdg_dir("XDG_RUNTIME_DIR").or_else(|| dirs::runtime_dir())
+}
+
+pub fn multishell_storage() -> PathBuf {
+    runtime_dir()
+        .or_else(state_dir)
+        .or_else(cache_dir)
+        .unwrap_or_else(|| std::env::temp_dir())
+        .join("fnm_multishells")
+}

--- a/src/directories.rs
+++ b/src/directories.rs
@@ -6,21 +6,21 @@ fn xdg_dir(env: &str) -> Option<PathBuf> {
 }
 
 fn state_dir() -> Option<PathBuf> {
-    xdg_dir("XDG_STATE_HOME").or_else(|| dirs::state_dir())
+    xdg_dir("XDG_STATE_HOME").or_else(dirs::state_dir)
 }
 
 fn cache_dir() -> Option<PathBuf> {
-    xdg_dir("XDG_CACHE_HOME").or_else(|| dirs::cache_dir())
+    xdg_dir("XDG_CACHE_HOME").or_else(dirs::cache_dir)
 }
 
 fn runtime_dir() -> Option<PathBuf> {
-    xdg_dir("XDG_RUNTIME_DIR").or_else(|| dirs::runtime_dir())
+    xdg_dir("XDG_RUNTIME_DIR").or_else(dirs::runtime_dir)
 }
 
 pub fn multishell_storage() -> PathBuf {
     runtime_dir()
         .or_else(state_dir)
         .or_else(cache_dir)
-        .unwrap_or_else(|| std::env::temp_dir())
+        .unwrap_or_else(std::env::temp_dir)
         .join("fnm_multishells")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ mod version_files;
 #[macro_use]
 mod log_level;
 mod default_version;
+mod directories;
 
 fn main() {
     env_logger::init();


### PR DESCRIPTION
still with no cleanup, probably need to have --cleanup-duration=... for fnm env
or another command for cleaning up old symlinks.


Fixes #624