### PR TITLE
fix native-creds errors (using the unpublished version of reqwest)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,8 +1167,7 @@ dependencies = [
 [[package]]
 name = "reqwest"
 version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
+source = "git+https://github.com/seanmonstar/reqwest.git?rev=d92d2aa3ce4667faa38454c8dae4fa9f72b91b71#d92d2aa3ce4667faa38454c8dae4fa9f72b91b71"
 dependencies = [
  "async-compression",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ log = "0.4.14"
 env_logger = "0.9.0"
 atty = "0.2.14"
 encoding_rs_io = "0.1.7"
-reqwest = { version = "0.11.9", features = ["blocking", "json", "rustls-tls", "rustls-tls-native-roots", "brotli"], default-features = false }
+reqwest = { git = "https://github.com/seanmonstar/reqwest.git", rev = "d92d2aa3ce4667faa38454c8dae4fa9f72b91b71", features = ["blocking", "json", "rustls-tls", "rustls-tls-native-roots", "brotli"], default-features = false }
 url = "2.2.2"
 sysinfo = "0.23.0"
 thiserror = "1.0.30"


### PR DESCRIPTION
after https://github.com/seanmonstar/reqwest/commit/d92d2aa3ce4667faa38454c8dae4fa9f72b91b71 lands which would be in any version > 0.11.9, we can go back to published versions.

This commit should fix issues with native-certs.

Related:

- Fixes #629
- Fixes #650
