### PR TITLE
perf: cargo release profile lto, strip & codegen opt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,17 @@ csv = "1.1.6"
 junction = "0.2.0"
 
 [features]
+
+[profile.release]
+lto = "fat"
+strip = "symbols"
+codegen-units = 1
+opt-level = 3
+
+[profile.release.build-override]
+opt-level = 3
+codegen-units = 1
+
+[profile.release.package."*"]
+codegen-units = 1
+opt-level = 3


### PR DESCRIPTION
These changes instrument cargo to use lto over everything and strip symbols. Cargo will optimize code over 1 codegen unit (instead of 16) and force to use the `opt-level` 3 setting, this will be enforced not only for the package itself but any build scripts and packages.