### PR TITLE
Remove UPX for ARM

### DIFF
--- a/.changeset/real-mayflies-watch.md
+++ b/.changeset/real-mayflies-watch.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+remove upx compression from arm binaries because it fails to build on latest rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -287,11 +287,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: "Build release"
       run: cross build --target $RUST_TARGET --release
-    - name: Compress binary using UPX
-      run: |
-        sudo apt-get update && sudo apt-get install -y upx
-        upx --version
-        upx target/$RUST_TARGET/release/fnm
     - uses: uraimo/run-on-arch-action@v2.1.2
       name: Sanity test
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -289,7 +289,8 @@ jobs:
       run: cross build --target $RUST_TARGET --release
     - name: Compress binary using UPX
       run: |
-        sudo apt-get install -y upx
+        sudo apt-get update && apt-get install -y upx
+        upx --version
         upx target/$RUST_TARGET/release/fnm
     - uses: uraimo/run-on-arch-action@v2.1.2
       name: Sanity test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -289,7 +289,7 @@ jobs:
       run: cross build --target $RUST_TARGET --release
     - name: Compress binary using UPX
       run: |
-        sudo apt-get update && apt-get install -y upx
+        sudo apt-get update && sudo apt-get install -y upx
         upx --version
         upx target/$RUST_TARGET/release/fnm
     - uses: uraimo/run-on-arch-action@v2.1.2


### PR DESCRIPTION
this updates upx because for some reason it can't compress the last version 🤔

if it stops working I'll stop using upx and ship a bigger binary, and fix that later
