### PR TITLE
fix(ci): Fix benchmark PR comment several times

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -414,11 +414,9 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
-          <!--benchy comment-->
           ## Linux Benchmarks for ${{ github.event.pull_request.head.sha }}
           ${{ steps.benchmark.outputs.markdown }}
-        comment_includes: '<!--benchy comment-->'
-
+        comment_tag: benchy
     - name: Create a commit comment
       if: ${{ !github.event.pull_request }}
       uses: peter-evans/commit-comment@v2


### PR DESCRIPTION
`thollander/actions-comment-pull-request@v2` deprecated `comment_include` in favor of `comment_tag`

This was causing a warning and the PR comment to be always recreated