### PR TITLE
Added Winget command to install fnm for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ brew install fnm
 
 Then, [set up your shell for fnm](#shell-setup)
 
+#### Using Winget (Windows)
+
+```sh
+winget install fnm
+```
+
+Then, [set up your shell for fnm](#shell-setup)
+
 #### Using Scoop (Windows)
 
 ```sh


### PR DESCRIPTION
By using Winget, we can avoid using an external package manager in windows.