### PR TITLE
Add winget as installation method on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ brew install fnm
 
 Then, [set up your shell for fnm](#shell-setup)
 
+#### Using Winget (Windows)
+
+```sh
+winget install Schniz.fnm
+```
+
 #### Using Scoop (Windows)
 
 ```sh


### PR DESCRIPTION
This tool is already available on Windows Package Manager (winget). winget ships by default with Windows 11 and it would easier to use winget for installing fnm