### PR TITLE
Writes logging to stderr to prevent programs starting a sub shell to error

### DIFF
--- a/src/log_level.rs
+++ b/src/log_level.rs
@@ -15,7 +15,7 @@ impl LogLevel {
         if self.is_writable(logging) {
             match logging {
                 Self::Error => Box::from(std::io::stderr()),
-                _ => Box::from(std::io::stdout()),
+                _ => Box::from(std::io::stderr()),
             }
         } else {
             Box::from(std::io::sink())


### PR DESCRIPTION
This week I ran into an [issue with neovide](https://github.com/neovide/neovide/issues/1858), a neovim gui (also written in rust).

Neovide starts neovim in a sub-shell and uses the neovim `--embed` mode to read and write `msgpack` messages to and from stdout.

When I start Neovide in a folder with a `.nvmrc` that defines a node version that is not my default, `fnm` prints a message and that ends up in the communication between Neovide and nvim and makes it crash.

Having unexpected output in `stdout` may affect other programs starting sub-shells as well so maybe it would be better to have all fnm log messages written to `stderr`?

What do you think?