### PR TITLE
Fixes issue where fnm print the node version string when using fish shell in non-interactive mode

### DIFF
--- a/.changeset/unlucky-sheep-scream.md
+++ b/.changeset/unlucky-sheep-scream.md
@@ -1,0 +1,5 @@
+---
+"fnm": minor
+---
+
+Adds switch to silently switch node versions and uses that switch in the fish shell environment command when fish is used non-interactively.

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -24,6 +24,11 @@ pub struct Use {
     /// if it will not change due to execution of this command
     #[clap(long)]
     silent_if_unchanged: bool,
+
+    /// Don't output a message identifying the version being used
+    /// even if it will change due to execution of this command
+    #[clap(long)]
+    silent: bool,
 }
 
 impl Command for Use {
@@ -88,7 +93,7 @@ impl Command for Use {
             }
         };
 
-        if !self.silent_if_unchanged || will_version_change(&version_path, config) {
+        if !self.silent && (!self.silent_if_unchanged || will_version_change(&version_path, config)) {
             outln!(config, Info, "{}", message);
         }
 
@@ -137,6 +142,7 @@ fn install_new_version(
         version: Some(UserVersionReader::Direct(requested_version)),
         install_if_missing: true,
         silent_if_unchanged: false,
+        silent: false,
     }
     .apply(config)?;
 

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -28,7 +28,11 @@ impl Shell for Fish {
             VersionFileStrategy::Local => indoc!(
                 r#"
                     if test -f .node-version -o -f .nvmrc
-                        fnm use --silent-if-unchanged
+                        if status is-interactive
+                            fnm use --silent-if-unchanged
+                        else
+                            fnm use --silent
+                        end
                     end
                 "#
             ),


### PR DESCRIPTION
This week I ran into an [issue with `Neovide`](https://github.com/neovide/neovide/issues/1858), a neovim gui (also written in rust).

I proposed GH-955 but did not feel this was the right fix for this issue, so this PR replaces that.

Neovide starts neovim in a sub-shell and uses the neovim --embed mode to read and write msgpack messages to and from stdout.

When I start Neovide in a folder with a `.nvmrc` that defines a node version that is not my default, `fnm` prints a message and that ends up in the communication between Neovide and nvim and makes it crash.

Neovide runs a non-interactive shell, and in that mode your shell init scripts are not supposed to print anything. In that mode, the shell typically don't ready `.bashrc` and similar. However, for the `fish` shell, it seems like it always reads config.fish (https://github.com/fish-shell/fish-shell/issues/5394).

This PR adds changes the behaviour of `fnm env --use-on-cd` for the `fish` shell to add a conditional check whether the shell is interactive or not. If `fish` is in non-interactive mode `fnm use` is started with a new switch `--silent` that will not let `fnm` output the version string even if the version will change.  