### PR TITLE
allow to automatically enable corepack

### DIFF
--- a/.changeset/dry-rocks-smash.md
+++ b/.changeset/dry-rocks-smash.md
@@ -1,0 +1,5 @@
+---
+"fnm": minor
+---
+
+Add --corepack-enabled flag for automatically enabling corepack on fnm install

--- a/.changeset/rare-otters-perform.md
+++ b/.changeset/rare-otters-perform.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+use cygwinpath to make the path posix-like on Windows Bash usage

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -13,6 +13,13 @@ OPTIONS:
 
             [env: FNM_ARCH]
 
+        --corepack-enabled
+            Enable corepack support for each new installation. This will make fnm call `corepack
+            enable` on every Node.js installation. For more information about corepack see
+            https://nodejs.org/api/corepack.html
+
+            [env: FNM_COREPACK_ENABLED=true]
+
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
 
@@ -101,6 +108,13 @@ OPTIONS:
 
             [env: FNM_ARCH]
 
+        --corepack-enabled
+            Enable corepack support for each new installation. This will make fnm call `corepack
+            enable` on every Node.js installation. For more information about corepack see
+            https://nodejs.org/api/corepack.html
+
+            [env: FNM_COREPACK_ENABLED=true]
+
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
 
@@ -150,6 +164,13 @@ OPTIONS:
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary
 
             [env: FNM_ARCH]
+
+        --corepack-enabled
+            Enable corepack support for each new installation. This will make fnm call `corepack
+            enable` on every Node.js installation. For more information about corepack see
+            https://nodejs.org/api/corepack.html
+
+            [env: FNM_COREPACK_ENABLED=true]
 
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
@@ -203,6 +224,13 @@ OPTIONS:
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary
 
             [env: FNM_ARCH]
+
+        --corepack-enabled
+            Enable corepack support for each new installation. This will make fnm call `corepack
+            enable` on every Node.js installation. For more information about corepack see
+            https://nodejs.org/api/corepack.html
+
+            [env: FNM_COREPACK_ENABLED=true]
 
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
@@ -260,6 +288,13 @@ OPTIONS:
 
             [env: FNM_ARCH]
 
+        --corepack-enabled
+            Enable corepack support for each new installation. This will make fnm call `corepack
+            enable` on every Node.js installation. For more information about corepack see
+            https://nodejs.org/api/corepack.html
+
+            [env: FNM_COREPACK_ENABLED=true]
+
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
 
@@ -316,6 +351,13 @@ OPTIONS:
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary
 
             [env: FNM_ARCH]
+
+        --corepack-enabled
+            Enable corepack support for each new installation. This will make fnm call `corepack
+            enable` on every Node.js installation. For more information about corepack see
+            https://nodejs.org/api/corepack.html
+
+            [env: FNM_COREPACK_ENABLED=true]
 
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
@@ -387,6 +429,13 @@ OPTIONS:
 
             [env: FNM_ARCH]
 
+        --corepack-enabled
+            Enable corepack support for each new installation. This will make fnm call `corepack
+            enable` on every Node.js installation. For more information about corepack see
+            https://nodejs.org/api/corepack.html
+
+            [env: FNM_COREPACK_ENABLED=true]
+
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
 
@@ -450,6 +499,13 @@ OPTIONS:
 
             [env: FNM_ARCH]
 
+        --corepack-enabled
+            Enable corepack support for each new installation. This will make fnm call `corepack
+            enable` on every Node.js installation. For more information about corepack see
+            https://nodejs.org/api/corepack.html
+
+            [env: FNM_COREPACK_ENABLED=true]
+
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
 
@@ -506,6 +562,13 @@ OPTIONS:
 
             [env: FNM_ARCH]
 
+        --corepack-enabled
+            Enable corepack support for each new installation. This will make fnm call `corepack
+            enable` on every Node.js installation. For more information about corepack see
+            https://nodejs.org/api/corepack.html
+
+            [env: FNM_COREPACK_ENABLED=true]
+
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
 
@@ -555,6 +618,13 @@ OPTIONS:
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary
 
             [env: FNM_ARCH]
+
+        --corepack-enabled
+            Enable corepack support for each new installation. This will make fnm call `corepack
+            enable` on every Node.js installation. For more information about corepack see
+            https://nodejs.org/api/corepack.html
+
+            [env: FNM_COREPACK_ENABLED=true]
 
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
@@ -609,6 +679,13 @@ OPTIONS:
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary
 
             [env: FNM_ARCH]
+
+        --corepack-enabled
+            Enable corepack support for each new installation. This will make fnm call `corepack
+            enable` on every Node.js installation. For more information about corepack see
+            https://nodejs.org/api/corepack.html
+
+            [env: FNM_COREPACK_ENABLED=true]
 
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
@@ -667,6 +744,13 @@ OPTIONS:
 
             [env: FNM_ARCH]
 
+        --corepack-enabled
+            Enable corepack support for each new installation. This will make fnm call `corepack
+            enable` on every Node.js installation. For more information about corepack see
+            https://nodejs.org/api/corepack.html
+
+            [env: FNM_COREPACK_ENABLED=true]
+
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
 
@@ -720,6 +804,13 @@ OPTIONS:
             Override the architecture of the installed Node binary. Defaults to arch of fnm binary
 
             [env: FNM_ARCH]
+
+        --corepack-enabled
+            Enable corepack support for each new installation. This will make fnm call `corepack
+            enable` on every Node.js installation. For more information about corepack see
+            https://nodejs.org/api/corepack.html
+
+            [env: FNM_COREPACK_ENABLED=true]
 
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -18,7 +18,7 @@ OPTIONS:
             enable` on every Node.js installation. For more information about corepack see
             https://nodejs.org/api/corepack.html
 
-            [env: FNM_COREPACK_ENABLED=true]
+            [env: FNM_COREPACK_ENABLED]
 
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
@@ -113,7 +113,7 @@ OPTIONS:
             enable` on every Node.js installation. For more information about corepack see
             https://nodejs.org/api/corepack.html
 
-            [env: FNM_COREPACK_ENABLED=true]
+            [env: FNM_COREPACK_ENABLED]
 
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
@@ -170,7 +170,7 @@ OPTIONS:
             enable` on every Node.js installation. For more information about corepack see
             https://nodejs.org/api/corepack.html
 
-            [env: FNM_COREPACK_ENABLED=true]
+            [env: FNM_COREPACK_ENABLED]
 
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
@@ -230,7 +230,7 @@ OPTIONS:
             enable` on every Node.js installation. For more information about corepack see
             https://nodejs.org/api/corepack.html
 
-            [env: FNM_COREPACK_ENABLED=true]
+            [env: FNM_COREPACK_ENABLED]
 
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
@@ -293,7 +293,7 @@ OPTIONS:
             enable` on every Node.js installation. For more information about corepack see
             https://nodejs.org/api/corepack.html
 
-            [env: FNM_COREPACK_ENABLED=true]
+            [env: FNM_COREPACK_ENABLED]
 
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
@@ -357,7 +357,7 @@ OPTIONS:
             enable` on every Node.js installation. For more information about corepack see
             https://nodejs.org/api/corepack.html
 
-            [env: FNM_COREPACK_ENABLED=true]
+            [env: FNM_COREPACK_ENABLED]
 
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
@@ -434,7 +434,7 @@ OPTIONS:
             enable` on every Node.js installation. For more information about corepack see
             https://nodejs.org/api/corepack.html
 
-            [env: FNM_COREPACK_ENABLED=true]
+            [env: FNM_COREPACK_ENABLED]
 
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
@@ -504,7 +504,7 @@ OPTIONS:
             enable` on every Node.js installation. For more information about corepack see
             https://nodejs.org/api/corepack.html
 
-            [env: FNM_COREPACK_ENABLED=true]
+            [env: FNM_COREPACK_ENABLED]
 
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
@@ -567,7 +567,7 @@ OPTIONS:
             enable` on every Node.js installation. For more information about corepack see
             https://nodejs.org/api/corepack.html
 
-            [env: FNM_COREPACK_ENABLED=true]
+            [env: FNM_COREPACK_ENABLED]
 
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
@@ -624,7 +624,7 @@ OPTIONS:
             enable` on every Node.js installation. For more information about corepack see
             https://nodejs.org/api/corepack.html
 
-            [env: FNM_COREPACK_ENABLED=true]
+            [env: FNM_COREPACK_ENABLED]
 
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
@@ -685,7 +685,7 @@ OPTIONS:
             enable` on every Node.js installation. For more information about corepack see
             https://nodejs.org/api/corepack.html
 
-            [env: FNM_COREPACK_ENABLED=true]
+            [env: FNM_COREPACK_ENABLED]
 
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
@@ -749,7 +749,7 @@ OPTIONS:
             enable` on every Node.js installation. For more information about corepack see
             https://nodejs.org/api/corepack.html
 
-            [env: FNM_COREPACK_ENABLED=true]
+            [env: FNM_COREPACK_ENABLED]
 
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations
@@ -810,7 +810,7 @@ OPTIONS:
             enable` on every Node.js installation. For more information about corepack see
             https://nodejs.org/api/corepack.html
 
-            [env: FNM_COREPACK_ENABLED=true]
+            [env: FNM_COREPACK_ENABLED]
 
         --fnm-dir <BASE_DIR>
             The root directory of fnm installations

--- a/e2e/__snapshots__/corepack.test.ts.snap
+++ b/e2e/__snapshots__/corepack.test.ts.snap
@@ -6,3 +6,23 @@ eval "$(fnm env --corepack-enabled)"
 fnm install 18
 fnm exec --using=18 node test-pnpm-corepack.js"
 `;
+
+exports[`Fish installs corepack: Fish 1`] = `
+"fnm env --corepack-enabled | source
+fnm install 18
+fnm exec --using=18 node test-pnpm-corepack.js"
+`;
+
+exports[`PowerShell installs corepack: PowerShell 1`] = `
+"$ErrorActionPreference = "Stop"
+fnm env --corepack-enabled | Out-String | Invoke-Expression
+fnm install 18
+fnm exec --using=18 node test-pnpm-corepack.js"
+`;
+
+exports[`Zsh installs corepack: Zsh 1`] = `
+"set -e
+eval "$(fnm env --corepack-enabled)"
+fnm install 18
+fnm exec --using=18 node test-pnpm-corepack.js"
+`;

--- a/e2e/__snapshots__/corepack.test.ts.snap
+++ b/e2e/__snapshots__/corepack.test.ts.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Bash installs corepack: Bash 1`] = `
+"set -e
+eval "$(fnm env --corepack-enabled)"
+fnm install 18
+fnm exec --using=18 node test-pnpm-corepack.js"
+`;

--- a/e2e/corepack.test.ts
+++ b/e2e/corepack.test.ts
@@ -1,0 +1,48 @@
+import fs from "fs"
+import { script } from "./shellcode/script.js"
+import { Bash, Fish, PowerShell, Zsh } from "./shellcode/shells.js"
+import describe from "./describe.js"
+import path from "path"
+import testCwd from "./shellcode/test-cwd.js"
+
+const nodescript = `
+  const pnpmBinary = require('child_process').execSync('which pnpm', { encoding: 'utf8' }).trim()
+  const nodeBinary = require('child_process').execSync('which node', { encoding: 'utf8' }).trim()
+
+  const binPath = require('path').dirname(nodeBinary);
+
+  if (!pnpmBinary.includes(binPath)) {
+    console.log('pnpm not found in current Node.js bin', { binPath, pnpmBinary });
+    process.exit(1);
+  }
+  const scriptContents = require('fs').readFileSync(pnpmBinary, 'utf8');
+  console.log('scriptContents', scriptContents)
+  if (!scriptContents.includes('corepack')) {
+    console.log('corepack not found in pnpm script');
+    process.exit(1);
+  }
+`
+
+for (const shell of [Bash]) {
+  describe(shell, () => {
+    test(`installs corepack`, async () => {
+      const cwd = testCwd()
+      const filepath = path.join(cwd, "test-pnpm-corepack.js")
+      fs.writeFileSync(filepath, nodescript)
+
+      await script(shell)
+        .then(shell.env({ corepackEnabled: true }))
+        .then(shell.call("fnm", ["install", "18"]))
+        .then(
+          shell.call("fnm", [
+            "exec",
+            "--using=18",
+            "node",
+            "test-pnpm-corepack.js",
+          ])
+        )
+        .takeSnapshot(shell)
+        .execute(shell)
+    })
+  })
+}

--- a/e2e/corepack.test.ts
+++ b/e2e/corepack.test.ts
@@ -4,9 +4,13 @@ import { Bash, Fish, PowerShell, Zsh } from "./shellcode/shells.js"
 import describe from "./describe.js"
 import path from "path"
 import testCwd from "./shellcode/test-cwd.js"
+import { createRequire } from "module"
+
+const require = createRequire(import.meta.url)
+const whichPath = require.resolve("which")
 
 const nodescript = `
-  const which = require('which');
+  const which = require(${JSON.stringify(whichPath)});
   const pnpmBinary = which.sync('pnpm')
   const nodeBinary = which.sync('node')
 

--- a/e2e/corepack.test.ts
+++ b/e2e/corepack.test.ts
@@ -6,8 +6,9 @@ import path from "path"
 import testCwd from "./shellcode/test-cwd.js"
 
 const nodescript = `
-  const pnpmBinary = require('child_process').execSync('which pnpm', { encoding: 'utf8' }).trim()
-  const nodeBinary = require('child_process').execSync('which node', { encoding: 'utf8' }).trim()
+  const which = require('which');
+  const pnpmBinary = which.sync('pnpm')
+  const nodeBinary = which.sync('node')
 
   const binPath = require('path').dirname(nodeBinary);
 
@@ -42,7 +43,7 @@ for (const shell of [Bash, Fish, PowerShell, Zsh]) {
           ])
         )
         .takeSnapshot(shell)
-        .addExtraEnvVar("RUST_LOG", "fnm=debug")
+        // .addExtraEnvVar("RUST_LOG", "fnm=debug")
         .execute(shell)
     })
   })

--- a/e2e/corepack.test.ts
+++ b/e2e/corepack.test.ts
@@ -23,7 +23,7 @@ const nodescript = `
   }
 `
 
-for (const shell of [Bash]) {
+for (const shell of [Bash, Fish, PowerShell, Zsh]) {
   describe(shell, () => {
     test(`installs corepack`, async () => {
       const cwd = testCwd()

--- a/e2e/corepack.test.ts
+++ b/e2e/corepack.test.ts
@@ -42,6 +42,7 @@ for (const shell of [Bash, Fish, PowerShell, Zsh]) {
           ])
         )
         .takeSnapshot(shell)
+        .addExtraEnvVar("RUST_LOG", "fnm=debug")
         .execute(shell)
     })
   })

--- a/e2e/env.test.ts
+++ b/e2e/env.test.ts
@@ -26,6 +26,7 @@ for (const shell of [Bash, Zsh, Fish, PowerShell, WinCmd]) {
           FNM_LOGLEVEL: "info",
           FNM_MULTISHELL_PATH: expect.any(String),
           FNM_NODE_DIST_MIRROR: expect.any(String),
+          FNM_COREPACK_ENABLED: "false",
           FNM_VERSION_FILE_STRATEGY: "local",
         })
       }

--- a/e2e/shellcode/shells/cmdEnv.ts
+++ b/e2e/shellcode/shells/cmdEnv.ts
@@ -1,14 +1,19 @@
 import { ScriptLine, define } from "./types.js"
 
-type EnvConfig = { useOnCd: boolean; logLevel: string }
+type EnvConfig = {
+  useOnCd: boolean
+  logLevel: string
+  corepackEnabled: boolean
+}
 export type HasEnv = { env(cfg: Partial<EnvConfig>): ScriptLine }
 
 function stringify(envConfig: Partial<EnvConfig> = {}) {
-  const { useOnCd, logLevel } = envConfig
+  const { useOnCd, logLevel, corepackEnabled } = envConfig
   return [
     `fnm env`,
     useOnCd && "--use-on-cd",
     logLevel && `--log-level=${logLevel}`,
+    corepackEnabled && "--corepack-enabled",
   ]
     .filter(Boolean)
     .join(" ")

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ts-dedent": "^2.2.0",
     "ts-jest": "^29.0.3",
     "typescript": "^4.8.4",
+    "which": "^3.0.1",
     "zod": "^3.19.1"
   },
   "prettier": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,7 @@ specifiers:
   ts-dedent: ^2.2.0
   ts-jest: ^29.0.3
   typescript: ^4.8.4
+  which: ^3.0.1
   zod: ^3.19.1
 
 devDependencies:
@@ -44,6 +45,7 @@ devDependencies:
   ts-dedent: 2.2.0
   ts-jest: 29.0.3_4f6uxrzmuwipl5rr3bcogf6k74
   typescript: 4.9.3
+  which: 3.0.1
   zod: 3.19.1
 
 packages:
@@ -5052,6 +5054,14 @@ packages:
   /which/2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+    dependencies:
+      isexe: 2.0.0
+    dev: true
+
+  /which/3.0.1:
+    resolution: {integrity: sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     hasBin: true
     dependencies:
       isexe: 2.0.0

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -25,7 +25,7 @@ pub fn get_safe_arch<'a>(arch: &'a Arch, version: &Version) -> &'a Arch {
 #[cfg(windows)]
 /// handle common case: Apple Silicon / Node < 16
 pub fn get_safe_arch<'a>(arch: &'a Arch, _version: &Version) -> &'a Arch {
-    return &arch;
+    arch
 }
 
 impl Default for Arch {

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -91,6 +91,10 @@ impl Command for Env {
                 "FNM_NODE_DIST_MIRROR",
                 config.node_dist_mirror.as_str().to_owned(),
             ),
+            (
+                "FNM_COREPACK_ENABLED",
+                config.corepack_enabled().to_string(),
+            ),
             ("FNM_ARCH", config.arch.to_string()),
         ]);
 

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -23,6 +23,25 @@ pub struct Exec {
     arguments: Vec<String>,
 }
 
+impl Exec {
+    pub(crate) fn new_for_version(
+        version: &crate::version::Version,
+        cmd: &str,
+        arguments: &[&str],
+    ) -> Self {
+        let reader = UserVersionReader::Direct(UserVersion::Full(version.clone()));
+        let args: Vec<_> = std::iter::once(cmd)
+            .chain(arguments.iter().copied())
+            .map(String::from)
+            .collect();
+        Self {
+            version: Some(reader),
+            using_file: false,
+            arguments: args,
+        }
+    }
+}
+
 impl Cmd for Exec {
     type Error = Error;
 

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -111,7 +111,7 @@ impl Cmd for Exec {
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("Can't spawn program: {}\nMaybe the program {} does not exist on not available in your PATH?", source, binary)]
+    #[error("Can't spawn program: {source}\nMaybe the program {} does not exist on not available in PATH?", binary.bold())]
     CantSpawnProgram {
         source: std::io::Error,
         binary: String,

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -4,6 +4,7 @@ use crate::current_version::current_version;
 use crate::fs;
 use crate::installed_versions;
 use crate::outln;
+use crate::shell;
 use crate::system_version;
 use crate::user_version::UserVersion;
 use crate::version::Version;
@@ -190,8 +191,11 @@ fn warn_if_multishell_path_not_in_path_env_var(
         multishell_path.to_path_buf()
     };
 
+    let fixed_path = bin_path.to_str().and_then(shell::maybe_fix_windows_path);
+    let fixed_path = fixed_path.as_ref().map(|x| &x[..]);
+
     for path in std::env::split_paths(&std::env::var("PATH").unwrap_or_default()) {
-        if bin_path == path {
+        if bin_path == path || fixed_path == path.to_str() {
             return;
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,12 @@ pub struct FnmConfig {
         hide_env_values = true,
     )]
     version_file_strategy: VersionFileStrategy,
+
+    /// Enable corepack support for each new installation.
+    /// This will make fnm call `corepack enable` on every Node.js installation.
+    /// For more information about corepack see https://nodejs.org/api/corepack.html
+    #[clap(long, env = "FNM_COREPACK_ENABLED", global = true)]
+    corepack_enabled: bool,
 }
 
 impl Default for FnmConfig {
@@ -81,6 +87,7 @@ impl Default for FnmConfig {
             log_level: LogLevel::Info,
             arch: Arch::default(),
             version_file_strategy: VersionFileStrategy::default(),
+            corepack_enabled: false,
         }
     }
 }
@@ -88,6 +95,10 @@ impl Default for FnmConfig {
 impl FnmConfig {
     pub fn version_file_strategy(&self) -> &VersionFileStrategy {
         &self.version_file_strategy
+    }
+
+    pub fn corepack_enabled(&self) -> bool {
+        self.corepack_enabled
     }
 
     pub fn multishell_path(&self) -> Option<&std::path::Path> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,7 +74,12 @@ pub struct FnmConfig {
     /// Enable corepack support for each new installation.
     /// This will make fnm call `corepack enable` on every Node.js installation.
     /// For more information about corepack see https://nodejs.org/api/corepack.html
-    #[clap(long, env = "FNM_COREPACK_ENABLED", global = true)]
+    #[clap(
+        long,
+        env = "FNM_COREPACK_ENABLED",
+        global = true,
+        hide_env_values = true
+    )]
     corepack_enabled: bool,
 }
 

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -16,6 +16,8 @@ impl Shell for Bash {
         let path = path
             .to_str()
             .ok_or_else(|| anyhow::anyhow!("Can't convert path to string"))?;
+        let path =
+            super::windows_compat::maybe_fix_windows_path(path).unwrap_or_else(|| path.to_string());
         Ok(format!("export PATH={path:?}:$PATH"))
     }
 

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -16,6 +16,8 @@ impl Shell for Fish {
         let path = path
             .to_str()
             .ok_or_else(|| anyhow::anyhow!("Can't convert path to string"))?;
+        let path =
+            super::windows_compat::maybe_fix_windows_path(path).unwrap_or_else(|| path.to_string());
         Ok(format!("set -gx PATH {path:?} $PATH;"))
     }
 

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -15,4 +15,5 @@ pub use infer::infer_shell;
 pub use powershell::PowerShell;
 pub use shell::{Shell, AVAILABLE_SHELLS};
 pub use windows_cmd::WindowsCmd;
+pub use windows_compat::maybe_fix_windows_path;
 pub use zsh::Zsh;

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -7,6 +7,7 @@ mod zsh;
 
 #[allow(clippy::module_inception)]
 mod shell;
+mod windows_compat;
 
 pub use bash::Bash;
 pub use fish::Fish;

--- a/src/shell/windows_compat.rs
+++ b/src/shell/windows_compat.rs
@@ -1,0 +1,18 @@
+/// On Bash for Windows, we need to convert the path from a Windows-style
+/// path to a Unix-style path. This is because Bash for Windows doesn't
+/// understand Windows-style paths. We use `cygpath` to do this conversion.
+/// If `cygpath` fails, we assume we're not on Bash for Windows and just
+/// return the original path.
+pub fn maybe_fix_windows_path(path: &str) -> Option<String> {
+    if !cfg!(windows) {
+        return None;
+    }
+
+    use std::process::Command;
+    let output = Command::new("cygpath").arg(path).output().ok()?;
+    if output.status.success() {
+        String::from_utf8(output.stdout).ok()
+    } else {
+        None
+    }
+}

--- a/src/shell/windows_compat.rs
+++ b/src/shell/windows_compat.rs
@@ -13,7 +13,8 @@ pub fn maybe_fix_windows_path(path: &str) -> Option<String> {
         .output()
         .ok()?;
     if output.status.success() {
-        String::from_utf8(output.stdout).ok()
+        let output = String::from_utf8(output.stdout).ok()?;
+        Some(output.trim().to_string())
     } else {
         None
     }

--- a/src/shell/windows_compat.rs
+++ b/src/shell/windows_compat.rs
@@ -8,8 +8,10 @@ pub fn maybe_fix_windows_path(path: &str) -> Option<String> {
         return None;
     }
 
-    use std::process::Command;
-    let output = Command::new("cygpath").arg(path).output().ok()?;
+    let output = std::process::Command::new("cygpath")
+        .arg(path)
+        .output()
+        .ok()?;
     if output.status.success() {
         String::from_utf8(output.stdout).ok()
     } else {

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -16,6 +16,8 @@ impl Shell for Zsh {
         let path = path
             .to_str()
             .ok_or_else(|| anyhow::anyhow!("Path is not valid UTF-8"))?;
+        let path =
+            super::windows_compat::maybe_fix_windows_path(path).unwrap_or_else(|| path.to_string());
         Ok(format!("export PATH={path:?}:$PATH"))
     }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -77,6 +77,9 @@ impl Version {
     }
 }
 
+// TODO: add a trait called BinPath that &Path and PathBuf implements
+// which adds the `.bin_path()` which works both on windows and unix :)
+
 impl<'de> serde::Deserialize<'de> for Version {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/version_file_strategy.rs
+++ b/src/version_file_strategy.rs
@@ -1,7 +1,8 @@
 use std::str::FromStr;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum VersionFileStrategy {
+    #[default]
     Local,
     Recursive,
 }
@@ -19,12 +20,6 @@ impl VersionFileStrategy {
     }
 }
 
-impl Default for VersionFileStrategy {
-    fn default() -> Self {
-        VersionFileStrategy::Local
-    }
-}
-
 impl FromStr for VersionFileStrategy {
     type Err = String;
 
@@ -33,8 +28,7 @@ impl FromStr for VersionFileStrategy {
             "local" => Ok(VersionFileStrategy::Local),
             "recursive" => Ok(VersionFileStrategy::Recursive),
             _ => Err(format!(
-                "Invalid strategy: {}. Expected one of: local, recursive",
-                s
+                "Invalid strategy: {s}. Expected one of: local, recursive",
             )),
         }
     }


### PR DESCRIPTION
as corepack becomes more and more mainstream, we need to make sure it's nice to use it with fnm.
it's still experimental so it's not happening automatically, but it's easy to set up now.

cc @styfle who nerd-sniped me <picture data-single-emoji=":relieved-telegram:" title=":relieved-telegram:"><img class="emoji" width="20" height="auto" src="https://emoji.slack-edge.com/T0CAQ00TU/relieved-telegram/c1d17d63d72a070c.gif" alt=":relieved-telegram:" align="absmiddle"></picture> 

fixes #566
(fixes #390 because it is required for this to land)