### PR TITLE
Replace atty with std::io::IsTerminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,6 @@ name = "fnm"
 version = "1.33.1"
 dependencies = [
  "anyhow",
- "atty",
  "chrono",
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ tempfile = "3.3.0"
 indoc = "1.0.8"
 log = "0.4.17"
 env_logger = "0.10.0"
-atty = "0.2.14"
 encoding_rs_io = "0.1.7"
 reqwest = { version = "0.11.13", features = ["blocking", "json", "rustls-tls", "rustls-tls-native-roots", "brotli"], default-features = false }
 url = "2.3.1"

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -158,9 +158,9 @@ fn replace_symlink(from: &std::path::Path, to: &std::path::Path) -> std::io::Res
 }
 
 fn should_install_interactively(requested_version: &UserVersion) -> bool {
-    use std::io::Write;
+    use std::io::{IsTerminal, Write};
 
-    if !(atty::is(atty::Stream::Stdout) && atty::is(atty::Stream::Stdin)) {
+    if !(std::io::stdout().is_terminal() && std::io::stdin().is_terminal()) {
         return false;
     }
 


### PR DESCRIPTION
According to the GitHub Action config to build `fnm`, the stable version of Rust seems to be used. Therefore [`std::io::IsTerminal`](https://doc.rust-lang.org/stable/std/io/trait.IsTerminal.html) might be able to be used, which was stabilized at 1.70.