### PR TITLE
Add powershell script for installation on windows

### DIFF
--- a/.ci/install.ps1
+++ b/.ci/install.ps1
@@ -1,0 +1,46 @@
+#!/usr/bin/env powershell
+
+param(
+  [string]$version = "latest",
+  [string]$installDir = "$env:USERPROFILE\.fnm",
+  [switch]$skipShell = $false
+)
+
+$ErrorActionPreference = 'Stop'
+
+# if version is not latest
+if (!$version.Equals("latest")) {
+  # and it does not start with a v
+  if (!$version.StartsWith("v")) {
+    # append a v in front
+    $version = "v$version"
+  }
+}
+$Target = 'fnm-windows.zip'
+
+$Url = if ($version.Equals("latest")) {
+  "https://github.com/Schniz/fnm/releases/latest/download/$Target"
+} else {
+  "https://github.com/Schniz/fnm/releases/download/$version/$Target"
+}
+
+# If installation dir does not exist, create it
+if (!(Test-Path $installDir)) {
+  New-Item $installDir -ItemType Directory | Out-Nul
+}
+
+Write-Output "Downloading from $Url"
+
+Invoke-RestMethod $Url -OutFile "$installDir\fnm.zip"
+
+Write-Output "Extracting file to $installDir"
+
+Expand-Archive "$installDir\fnm.zip" -DestinationPath "$installDir" -Force
+
+# Delete the zip file
+Remove-Item "$installDir\fnm.zip"
+
+if (!$skipShell) {
+  Write-Output "Appending 'fnm env --use-on-cd | Out-String | Invoke-Expression' to profile"
+  Add-Content "$profile" "fnm env --use-on-cd | Out-String | Invoke-Expression"
+}


### PR DESCRIPTION
This adds a powershell script for installing fnm on windows. The ps script tries to follow the bash script as much as possible. Supported flags are:
- -version | -v for setting version (string)
- -skipShell | -s for skipping shell setup (bool)
- -installDir for setting installation dir (string)

Using only one `-` seems odd to me but thats how powershell parses arguments. As far as i've tested, it even works with only the first argument too, as in `-version`, `-v` and `-V` all do the same thing. 

To install fnm via the script, users would do
```powershell
$ irm url/to/the/script | iex
```
The bash script uses the `install` endpoint, the ps script could do ig `https://fnm.vercel.app/install.ps` or something. 

I've tested the script a few times and ensured that it works. 