### PR TITLE
Add progress bar to install command

### DIFF
--- a/.changeset/show-download-progress.md
+++ b/.changeset/show-download-progress.md
@@ -1,0 +1,5 @@
+---
+"fnm": minor
+---
+
+Show a progress bar when downloading and extracting node

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,6 +358,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,6 +554,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +657,7 @@ dependencies = [
  "embed-resource",
  "encoding_rs_io",
  "env_logger",
+ "indicatif",
  "indoc",
  "junction",
  "log",
@@ -913,6 +933,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b297dc40733f23a0e52728a58fa9489a5b7638a324932de16b41adc3ef80730"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1198,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "object"
 version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,6 +1286,12 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "portable-atomic"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f32154ba0af3a075eefa1eda8bb414ee928f62303a54ea85b8d6638ff1a6ee9e"
 
 [[package]]
 name = "pretty_assertions"
@@ -2112,7 +2157,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -2132,11 +2177,35 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ sysinfo = "0.29.3"
 thiserror = "1.0.44"
 clap_complete = "4.3.1"
 anyhow = "1.0.71"
+indicatif = "0.17.6"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -216,6 +216,9 @@ Options:
       --latest
           Install latest version
 
+      --no-progress
+          Do not display a progress bar
+
       --log-level <LOG_LEVEL>
           The log level of fnm commands
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod installed_versions;
 mod lts;
 mod package_json;
 mod path_ext;
+mod progress;
 mod remote_node_index;
 mod shell;
 mod system_info;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,55 @@
+use std::io::Read;
+
+use indicatif::{ProgressBar, ProgressStyle};
+use reqwest::blocking::Response;
+
+pub struct ResponseProgress {
+    progress: Option<ProgressBar>,
+    response: Response,
+}
+
+fn make_progress_bar(size: u64) -> ProgressBar {
+    let bar = ProgressBar::new(size);
+
+    bar.set_style(
+        ProgressStyle::default_bar()
+            .template("[{elapsed_precise}] [{bar:40}] {bytes}/{total_bytes} ({bytes_per_sec}, {eta})")
+            .unwrap()
+            .progress_chars("#>-")
+    );
+
+    bar
+}
+
+impl ResponseProgress {
+    pub fn new(response: Response) -> Self {
+        Self {
+            progress: response.content_length().map(make_progress_bar),
+            response,
+        }
+    }
+
+    pub fn finish(&self) {
+        if let Some(ref bar) = self.progress {
+            bar.finish();
+        }
+    }
+}
+
+impl Read for ResponseProgress {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let size = self.response.read(buf)?;
+
+        if let Some(ref bar) = self.progress {
+            bar.inc(size as u64);
+        }
+
+        Ok(size)
+    }
+}
+
+impl Drop for ResponseProgress {
+    fn drop(&mut self) {
+        self.finish()
+    }
+}


### PR DESCRIPTION
This adds the feature requested in #949. Doesn't display if the response from the download mirror doesn't have a content-length header.

I hard-coded a bar template, looks like this:

![image](https://github.com/Schniz/fnm/assets/55192399/3e33f958-5384-4279-9fa8-497a498ff5af)

I think we could add an env var to customize this, but we'd need to handle syntax errors gracefully (show warning, maybe?).

Added a `--no-progress` option to turn this off. It writes to stderr.