### PR TITLE
Allow for cd /D on windows

### DIFF
--- a/.changeset/many-paws-fetch.md
+++ b/.changeset/many-paws-fetch.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+Fix `cd /D` on windows with `--use-on-cd`

--- a/src/shell/windows_cmd/cd.cmd
+++ b/src/shell/windows_cmd/cd.cmd
@@ -1,5 +1,5 @@
 @echo off
-cd %1
+cd %*
 if "%FNM_VERSION_FILE_STRATEGY%" == "recursive" (
   fnm use --silent-if-unchanged
 ) else (


### PR DESCRIPTION
When installed on windows with the `--use-on-cd` flag. Using `cd /D <path>` will fail because only the `/D` argument is passed into the actual cd command.

Replacing %1 with %* will forward all the arguments so `cd /D <path>` functions.