### PR TITLE
fix: fish Completions error

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,20 @@ Where `<SHELL>` can be one of the supported shells:
 - `powershell`
 
 Please follow your shell instructions to install them.
+### Zsh
+```
+fnm completions --shell zsh > /usr/local/share/zsh/site-functions/_fnm
+compinit
+fnm --<TAB>
+```
+
+### Fish
+```
+fnm completions --shell fish > ./fnm.fish
+. ./fnm.fish
+fnm --<TAB>
+```
+
 
 ### Shell Setup
 

--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -3,6 +3,7 @@ use crate::config::FnmConfig;
 use crate::shell::{infer_shell, Shell};
 use crate::{cli::Cli, shell::Shells};
 use clap::{CommandFactory, Parser, ValueEnum};
+use clap_complete::generate;
 use clap_complete::{Generator, Shell as ClapShell};
 use thiserror::Error;
 
@@ -25,8 +26,8 @@ impl Command for Completions {
             .ok_or(Error::CantInferShell)?;
         let shell: ClapShell = shell.into();
         let mut app = Cli::command();
-        app.build();
-        shell.generate(&app, &mut stdio);
+        let name = app.get_name().to_string();
+        generate(shell, &mut app, name, &mut stdio);
         Ok(())
     }
 }


### PR DESCRIPTION
[fix!: Remove bookkeeping getters from API #4030
 ](https://github.com/clap-rs/clap/pull/4030/files#diff-22b7975053b03b305ab7920c9a063d4df40f386419020f4c3be24005eeb81eb5) may result in completion errors for fnm commands.
![image](https://github.com/Schniz/fnm/assets/19884146/8242fde2-f107-4ade-ac37-fceabc2c7407)
It works now~
![image](https://github.com/Schniz/fnm/assets/19884146/2e0dfe62-545e-4885-8ba5-d09f3489d8a5)
