### PR TITLE
fix: return default version if canonicalize fails

### DIFF
--- a/.changeset/rotten-pumpkins-search.md
+++ b/.changeset/rotten-pumpkins-search.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+fix: return default version if canonicalize fails

--- a/src/default_version.rs
+++ b/src/default_version.rs
@@ -3,7 +3,10 @@ use crate::version::Version;
 use std::str::FromStr;
 
 pub fn find_default_version(config: &FnmConfig) -> Option<Version> {
-    let version_path = config.default_version_dir().canonicalize().ok()?;
-    let file_name = version_path.parent()?.file_name()?;
-    Version::from_str(file_name.to_str()?).ok()?.into()
+    if let Ok(version_path) = config.default_version_dir().canonicalize() {
+        let file_name = version_path.parent()?.file_name()?;
+        Version::from_str(file_name.to_str()?).ok()?.into()
+    } else {
+        Some(Version::Alias("default".into()))
+    }
 }


### PR DESCRIPTION
Since `canonicalize` can fail when default on *nix operating systems is set to `system` (#681), I have changed `find_default_version` to return the default alias if `canonicalize` fails.