### PR TITLE
This $PATH should be wrapped in quotes so it will work with spaces

### DIFF
--- a/.changeset/violet-rice-brake.md
+++ b/.changeset/violet-rice-brake.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+Fixes a bug when running `eval $(fnm env)` in sh when there a spaces in the $PATH

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -18,7 +18,7 @@ impl Shell for Bash {
             .ok_or_else(|| anyhow::anyhow!("Can't convert path to string"))?;
         let path =
             super::windows_compat::maybe_fix_windows_path(path).unwrap_or_else(|| path.to_string());
-        Ok(format!("export PATH={path:?}:$PATH"))
+        Ok(format!("export PATH={path:?}:\"$PATH\""))
     }
 
     fn set_env_var(&self, name: &str, value: &str) -> String {


### PR DESCRIPTION
This $PATH use needs to be wrapped in quotes so it will expand properly if there are spaces within the $PATH. This seems to only effect sh, not bash.

To reproduce:
1. Run `PATH="space path:$PATH"`
2. Run `eval $(fnm env)`
3. At this point I would expect you to get the error: `sh: 1: export: path:rest/off/you/path/before/next/space: bad variable name`