### PR TITLE
Add workaround for endless loop of WinCMD script

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,18 @@ fnm is also supported but is not entirely covered. [You can set up a startup scr
 FOR /f "tokens=*" %i IN ('fnm env --use-on-cd') DO CALL %i
 ```
 
-⚠️ If you get the error `i was unexpected at this time`, please make a .cmd file as suggested by the first step in the Usage with Cmder secton add it's path to the `AutoRun` registry key.
+⚠️ If you get the error `i was unexpected at this time`, please make a .cmd file as suggested by the first step in the Usage with Cmder secton add it's path to the `AutoRun` registry key.  
+⚠️ If command hangs forever, try to wrap it inside [a loop check](https://stackoverflow.com/a/57451662): 
+```batch
+@echo off
+setlocal EnableDelayedExpansion
+set "cmd=!cmdcmdline!"
 
+if "!cmd!" == "!cmd:/=!" (
+  REM *** Stuff for AutoRun 
+  FOR /f "tokens=*" %%i IN ('fnm env --use-on-cd') DO CALL %%i
+)
+```
 #### Usage with Cmder
 
 Usage is very similar to the normal WinCMD install, apart for a few tweaks to allow being called from the cmder startup script. The example **assumes** that the `CMDER_ROOT` environment variable is **set** to the **root directory** of your Cmder installation.


### PR DESCRIPTION
I just set up the CMD auto run script in my windows machine (Windows 11 Enterprise, 23H2, x64) 
I firstly encountered `%i was unexpected at this time.`, so I changed to script the Cmder version (double the `%`)
after that, the cmd hangs forever, and a huge amount of cmd process emerged:
<img width="805" alt="image" src="https://github.com/Schniz/fnm/assets/5887203/1a4b6054-9bd5-4b7c-b495-93f97586bd4d">

I got the answer from https://stackoverflow.com/a/57451662
> The problem is, FOR /F starts a new instace of cmd.exe and that instance also starts your auto run script, this can result into an endless loop.

So I updated the README, hope my experience can help other peopoe
