### PR TITLE
fix: fish shell path duplicates

### DIFF
--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -18,7 +18,7 @@ impl Shell for Fish {
             .ok_or_else(|| anyhow::anyhow!("Can't convert path to string"))?;
         let path =
             super::windows_compat::maybe_fix_windows_path(path).unwrap_or_else(|| path.to_string());
-        Ok(format!("set -gx PATH {path:?} $PATH;"))
+        Ok(format!("fish_add_path -gP {path:?};"))
     }
 
     fn set_env_var(&self, name: &str, value: &str) -> String {


### PR DESCRIPTION
As fish will reappend the PATH by simply using `set -gx PATH...` you get duplicate entries if you have nested fish sessions (e.g. tmux). 
`fish_add_path -gP` ensures that the PATH is only set once and is prepended to the current PATH

references #441