### PR TITLE
fix: support x64-musl

### DIFF
--- a/.changeset/poor-otters-cheer.md
+++ b/.changeset/poor-otters-cheer.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+support `x64-musl` arch by adding a `--arch x64-musl` to fnm env

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -4,6 +4,7 @@ use crate::version::Version;
 pub enum Arch {
     X86,
     X64,
+    X64Musl,
     Arm64,
     Armv7l,
     Ppc64le,
@@ -43,6 +44,7 @@ impl std::str::FromStr for Arch {
         match s {
             "x86" => Ok(Arch::X86),
             "x64" => Ok(Arch::X64),
+            "x64-musl" => Ok(Arch::X64Musl),
             "arm64" => Ok(Arch::Arm64),
             "armv7l" => Ok(Arch::Armv7l),
             "ppc64le" => Ok(Arch::Ppc64le),
@@ -58,6 +60,7 @@ impl std::fmt::Display for Arch {
         let arch_str = match self {
             Arch::X86 => String::from("x86"),
             Arch::X64 => String::from("x64"),
+            Arch::X64Musl => String::from("x64-musl"),
             Arch::Arm64 => String::from("arm64"),
             Arch::Armv7l => String::from("armv7l"),
             Arch::Ppc64le => String::from("ppc64le"),


### PR DESCRIPTION
Yes, an easy fix as silly as bypassing the hardcoded check and then set `FNM_NODE_DIST_MIRROR` & `FNM_ARCH` in shell rc.