### PR TITLE
Updated README.md => Fixed infite Loop from Windows console startup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,15 +178,19 @@ fnm env --use-on-cd | Out-String | Invoke-Expression
   ```powershell
   notepad $profile
   ```
+  
 #### Windows Command Prompt aka Batch aka WinCMD
 
-fnm is also supported but is not entirely covered. [You can set up a startup script](https://superuser.com/a/144348) and append the following line:
+fnm is also supported but is not entirely covered. [You can set up a startup script](https://superuser.com/a/144348) and append the following lines:
 
 ```batch
-FOR /f "tokens=*" %i IN ('fnm env --use-on-cd') DO CALL %i
+@echo off
+:: for /F will launch a new instance of cmd so we create a guard to prevent an infnite loop
+if not defined FNM_AUTORUN_GUARD (
+    set "FNM_AUTORUN_GUARD=AutorunGuard"
+    FOR /f "tokens=*" %%z IN ('fnm env --use-on-cd') DO CALL %%z
+)
 ```
-
-⚠️ If you get the error `i was unexpected at this time`, please make a .cmd file as suggested by the first step in the Usage with Cmder secton add it's path to the `AutoRun` registry key.
 
 #### Usage with Cmder
 


### PR DESCRIPTION
The updated startup script does not produce the error "i was unexpected at this time" and also won't freeze the console because of an infite loop => "for /F" will launch a new instance of cmd.