### PR TITLE
Update configuration command for corepack

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,7 +46,7 @@ repo/packages/my-package$ fnm use
 error: Can't find version in dotfiles. Please provide a version manually to the command.
 ```
 
-### `--enable-corepack`
+### `--corepack-enabled`
 
 **🧪 Experimental**
 


### PR DESCRIPTION
Running the `fnm env --help` it looks like the command to autorun enable corepack on Node installation is `--corepack-enabled`.