### PR TITLE
Add `--shell` to `fnm env` commands in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Check out the following guides for the shell you use:
 Add the following to your `.bashrc` profile:
 
 ```bash
-eval "$(fnm env --use-on-cd)"
+eval "$(fnm env --use-on-cd --shell bash)"
 ```
 
 #### Zsh
@@ -157,7 +157,7 @@ eval "$(fnm env --use-on-cd)"
 Add the following to your `.zshrc` profile:
 
 ```zsh
-eval "$(fnm env --use-on-cd)"
+eval "$(fnm env --use-on-cd --shell zsh)"
 ```
 
 #### Fish shell
@@ -165,7 +165,7 @@ eval "$(fnm env --use-on-cd)"
 Create `~/.config/fish/conf.d/fnm.fish` and add this line to it:
 
 ```fish
-fnm env --use-on-cd | source
+fnm env --use-on-cd --shell fish | source
 ```
 
 #### PowerShell
@@ -173,7 +173,7 @@ fnm env --use-on-cd | source
 Add the following to the end of your profile file:
 
 ```powershell
-fnm env --use-on-cd | Out-String | Invoke-Expression
+fnm env --use-on-cd --shell power-shell | Out-String | Invoke-Expression
 ```
 
 - For macOS/Linux, the profile is located at `~/.config/powershell/Microsoft.PowerShell_profile.ps1`


### PR DESCRIPTION
When specifying `--shell`, the `fnm env` command takes about `1.3ms` instead of `54ms` on my machine. This is about 40x speedup.

The README has a section for every shell anyway, so adding the option saves some time on shell initialization.