### PR TITLE
Use `var_os` instead of `var

### DIFF
--- a/.changeset/var-os.md
+++ b/.changeset/var-os.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+Allow reading non-unicode paths from environment variables

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -185,16 +185,16 @@ fn warn_if_multishell_path_not_in_path_env_var(
     multishell_path: &std::path::Path,
     config: &FnmConfig,
 ) {
-    let bin_path = if cfg!(unix) {
-        multishell_path.join("bin")
-    } else {
-        multishell_path.to_path_buf()
-    };
-
-    let fixed_path = bin_path.to_str().and_then(shell::maybe_fix_windows_path);
-    let fixed_path = fixed_path.as_ref().map(|x| &x[..]);
-
     if let Some(path_var) = std::env::var_os("PATH") {
+        let bin_path = if cfg!(unix) {
+            multishell_path.join("bin")
+        } else {
+            multishell_path.to_path_buf()
+        };
+
+        let fixed_path = bin_path.to_str().and_then(shell::maybe_fix_windows_path);
+        let fixed_path = fixed_path.as_deref();
+
         for path in std::env::split_paths(&path_var) {
             if bin_path == path || fixed_path == path.to_str() {
                 return;

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -194,9 +194,11 @@ fn warn_if_multishell_path_not_in_path_env_var(
     let fixed_path = bin_path.to_str().and_then(shell::maybe_fix_windows_path);
     let fixed_path = fixed_path.as_ref().map(|x| &x[..]);
 
-    for path in std::env::split_paths(&std::env::var("PATH").unwrap_or_default()) {
-        if bin_path == path || fixed_path == path.to_str() {
-            return;
+    if let Some(path_var) = std::env::var_os("PATH") {
+        for path in std::env::split_paths(&path_var) {
+            if bin_path == path || fixed_path == path.to_str() {
+                return;
+            }
         }
     }
 

--- a/src/directories.rs
+++ b/src/directories.rs
@@ -5,7 +5,7 @@ use crate::path_ext::PathExt;
 
 fn xdg_dir(env: &str) -> Option<PathBuf> {
     if cfg!(windows) {
-        let env_var = std::env::var(env).ok()?;
+        let env_var = std::env::var_os(env)?;
         Some(PathBuf::from(env_var))
     } else {
         // On non-Windows platforms, `etcetera` already handles XDG variables


### PR DESCRIPTION
`var_os` doesn't need to check if the value of the variable is in UTF8. `split_paths` and `PathBuf` can deal with `OsString`