### PR TITLE
Add Windows arm64 release binaries

### DIFF
--- a/.changeset/heavy-seals-stare.md
+++ b/.changeset/heavy-seals-stare.md
@@ -1,0 +1,5 @@
+---
+"fnm": minor
+---
+
+feature: Add Windows arm64 release binaries

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -75,7 +75,13 @@ set_filename() {
     USE_HOMEBREW="true"
     echo "Downloading fnm using Homebrew..."
   elif [ "$OS" = "Windows" ] ; then
-    FILENAME="fnm-windows"
+    case "$(uname -m)" in
+      aarch* | armv8*)
+        FILENAME="fnm-windows-arm64"
+        ;;
+      *)
+        FILENAME="fnm-windows"
+    esac
     echo "Downloading the latest fnm binary from GitHub..."
   else
     echo "OS $OS is not supported."

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,16 +57,25 @@ jobs:
       - uses: hecrj/setup-rust-action@v1
         with:
           rust-version: ${{env.RUST_VERSION}}
+          targets: x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
       - uses: Swatinem/rust-cache@v2
       - uses: actions/checkout@v4
-      - name: Build release binary
+      - name: Build x64 release binary
         run: cargo build --release
+        env:
+          RUSTFLAGS: "-C target-feature=+crt-static"
+      - name: Build arm64 release binary
+        run: cargo build --release --target aarch64-pc-windows-msvc
         env:
           RUSTFLAGS: "-C target-feature=+crt-static"
       - uses: actions/upload-artifact@v4
         with:
           name: fnm-windows
           path: target/release/fnm.exe
+      - uses: actions/upload-artifact@v4
+        with:
+          name: fnm-windows-arm64
+          path: target/aarch64-pc-windows-msvc/release/fnm.exe
 
   build_macos_release:
     runs-on: macos-latest


### PR DESCRIPTION
Closes #1068 

Even though the GitHub Runner hosts are x64, MSVC and Rust support cross-compiling to arm64 perfectly fine on Windows. This PR uploads arm64 artifacts for `fnm`.