### PR TITLE
fix(install): actually tag versions if corepack is enabled

### DIFF
--- a/.changeset/purple-rocks-judge.md
+++ b/.changeset/purple-rocks-judge.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+set aliases during install, even if corepack is enabled

--- a/e2e/__snapshots__/aliases.test.ts.snap
+++ b/e2e/__snapshots__/aliases.test.ts.snap
@@ -53,6 +53,13 @@ eval "$(fnm env --log-level=error)"
 (fnm use 2>&1) | grep 'Requested version lts-latest is not' || (echo "Expected output to contain 'Requested version lts-latest is not'" && exit 1)"
 `;
 
+exports[`Bash installs aliases when corepack is enabled: Bash 1`] = `
+"set -e
+eval "$(fnm env --corepack-enabled)"
+fnm use --install-if-missing
+(fnm ls) | grep lts-latest || (echo "Expected output to contain lts-latest" && exit 1)"
+`;
+
 exports[`Bash unalias a version: Bash 1`] = `
 "set -e
 eval "$(fnm env)"
@@ -122,6 +129,12 @@ exports[`Fish errors when alias is not found: Fish 1`] = `
 begin; fnm use 2>&1; end | grep 'Requested version lts-latest is not'; or echo "Expected output to contain 'Requested version lts-latest is not'" && exit 1"
 `;
 
+exports[`Fish installs aliases when corepack is enabled: Fish 1`] = `
+"fnm env --corepack-enabled | source
+fnm use --install-if-missing
+begin; fnm ls; end | grep lts-latest; or echo "Expected output to contain lts-latest" && exit 1"
+`;
+
 exports[`Fish unalias a version: Fish 1`] = `
 "fnm env | source
 fnm install 11.10.0
@@ -179,6 +192,13 @@ exports[`PowerShell errors when alias is not found: PowerShell 1`] = `
 "$ErrorActionPreference = "Stop"
 fnm env --log-level=error | Out-String | Invoke-Expression
 $($__out__ = $(fnm use 2>&1 | Select-String 'Requested version lts-latest is not'); if ($__out__ -eq $null) { exit 1 } else { $__out__ })"
+`;
+
+exports[`PowerShell installs aliases when corepack is enabled: PowerShell 1`] = `
+"$ErrorActionPreference = "Stop"
+fnm env --corepack-enabled | Out-String | Invoke-Expression
+fnm use --install-if-missing
+$($__out__ = $(fnm ls | Select-String lts-latest); if ($__out__ -eq $null) { exit 1 } else { $__out__ })"
 `;
 
 exports[`PowerShell unalias a version: PowerShell 1`] = `
@@ -249,6 +269,13 @@ exports[`Zsh errors when alias is not found: Zsh 1`] = `
 "set -e
 eval "$(fnm env --log-level=error)"
 (fnm use 2>&1) | grep 'Requested version lts-latest is not' || (echo "Expected output to contain 'Requested version lts-latest is not'" && exit 1)"
+`;
+
+exports[`Zsh installs aliases when corepack is enabled: Zsh 1`] = `
+"set -e
+eval "$(fnm env --corepack-enabled)"
+fnm use --install-if-missing
+(fnm ls) | grep lts-latest || (echo "Expected output to contain lts-latest" && exit 1)"
 `;
 
 exports[`Zsh unalias a version: Zsh 1`] = `

--- a/e2e/aliases.test.ts
+++ b/e2e/aliases.test.ts
@@ -9,13 +9,25 @@ import testNodeVersion from "./shellcode/test-node-version.js"
 
 for (const shell of [Bash, Zsh, Fish, PowerShell]) {
   describe(shell, () => {
+    test(`installs aliases when corepack is enabled`, async () => {
+      await writeFile(path.join(testCwd(), ".node-version"), "lts/*")
+      await script(shell)
+        .then(shell.env({ corepackEnabled: true }))
+        .then(shell.call("fnm", ["use", "--install-if-missing"]))
+        .then(
+          shell.scriptOutputContains(shell.call("fnm", ["ls"]), "lts-latest"),
+        )
+        .takeSnapshot(shell)
+        .execute(shell)
+    })
+
     test(`allows to install an lts if version missing`, async () => {
       await writeFile(path.join(testCwd(), ".node-version"), "lts/*")
       await script(shell)
         .then(shell.env({}))
         .then(shell.call("fnm", ["use", "--install-if-missing"]))
         .then(
-          shell.scriptOutputContains(shell.call("fnm", ["ls"]), "lts-latest")
+          shell.scriptOutputContains(shell.call("fnm", ["ls"]), "lts-latest"),
         )
         .takeSnapshot(shell)
         .execute(shell)
@@ -28,8 +40,8 @@ for (const shell of [Bash, Zsh, Fish, PowerShell]) {
         .then(
           shell.scriptOutputContains(
             getStderr(shell.call("fnm", ["use"])),
-            "'Requested version lts-latest is not'"
-          )
+            "'Requested version lts-latest is not'",
+          ),
         )
         .takeSnapshot(shell)
         .execute(shell)
@@ -46,8 +58,8 @@ for (const shell of [Bash, Zsh, Fish, PowerShell]) {
         .then(
           shell.scriptOutputContains(
             getStderr(shell.call("fnm", ["use", "version8"])),
-            "'Requested version version8 is not currently installed'"
-          )
+            "'Requested version version8 is not currently installed'",
+          ),
         )
         .takeSnapshot(shell)
         .execute(shell)
@@ -59,8 +71,8 @@ for (const shell of [Bash, Zsh, Fish, PowerShell]) {
         .then(
           shell.scriptOutputContains(
             getStderr(shell.call("fnm", ["unalias", "lts"])),
-            "'Requested alias lts not found'"
-          )
+            "'Requested alias lts not found'",
+          ),
         )
         .takeSnapshot(shell)
         .execute(shell)
@@ -71,25 +83,25 @@ for (const shell of [Bash, Zsh, Fish, PowerShell]) {
         .then(shell.env({}))
         .then(shell.call("fnm", ["alias", "system", "my_system"]))
         .then(
-          shell.scriptOutputContains(shell.call("fnm", ["ls"]), "my_system")
+          shell.scriptOutputContains(shell.call("fnm", ["ls"]), "my_system"),
         )
         .then(shell.call("fnm", ["alias", "system", "default"]))
         .then(shell.call("fnm", ["alias", "my_system", "my_system2"]))
         .then(
-          shell.scriptOutputContains(shell.call("fnm", ["ls"]), "my_system2")
+          shell.scriptOutputContains(shell.call("fnm", ["ls"]), "my_system2"),
         )
         .then(
           shell.scriptOutputContains(
             shell.call("fnm", ["use", "my_system"]),
-            "'Bypassing fnm'"
-          )
+            "'Bypassing fnm'",
+          ),
         )
         .then(shell.call("fnm", ["unalias", "my_system"]))
         .then(
           shell.scriptOutputContains(
             getStderr(shell.call("fnm", ["use", "my_system"])),
-            "'Requested version my_system is not currently installed'"
-          )
+            "'Requested version my_system is not currently installed'",
+          ),
         )
         .takeSnapshot(shell)
         .execute(shell)
@@ -107,14 +119,14 @@ for (const shell of [Bash, Zsh, Fish, PowerShell]) {
         .then(
           shell.scriptOutputContains(
             shell.scriptOutputContains(installedVersions, "8.11.3"),
-            "oldie"
-          )
+            "oldie",
+          ),
         )
         .then(
           shell.scriptOutputContains(
             shell.scriptOutputContains(installedVersions, "6.11.3"),
-            "older"
-          )
+            "older",
+          ),
         )
         .then(shell.call("fnm", ["use", "older"]))
         .then(testNodeVersion(shell, "v6.11.3"))

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -151,11 +151,6 @@ impl Command for Install {
             Ok(()) => {}
         };
 
-        if config.corepack_enabled() {
-            outln!(config, Info, "Enabling corepack for {}", version_str.cyan());
-            enable_corepack(&version, config)?;
-        }
-
         if !config.default_version_dir().exists() {
             debug!("Tagging {} as the default version", version.v_str().cyan());
             create_alias(config, "default", &version)?;
@@ -163,6 +158,11 @@ impl Command for Install {
 
         if let Some(tagged_alias) = current_version.inferred_alias() {
             tag_alias(config, &version, &tagged_alias)?;
+        }
+
+        if config.corepack_enabled() {
+            outln!(config, Info, "Enabling corepack for {}", version_str.cyan());
+            enable_corepack(&version, config)?;
         }
 
         Ok(())


### PR DESCRIPTION
When corepack was enabled, newly installed versions were not tagged correctly. This is because the process would exit early when enabling corepack, due to the [std::process::exit](https://github.com/Schniz/fnm/blob/1a58394b53c918fa130e22116056f7b4f8e4997c/src/commands/exec.rs#L108) in Exec::apply. Moving the if block that runs enable_corepack after the aliases are set fixes this.

This PR fixes issue #1071.