### PR TITLE
fix: allow to type powershell and power-shell as shell type inputs

### DIFF
--- a/.changeset/cyan-crews-kneel.md
+++ b/.changeset/cyan-crews-kneel.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+fix: allow to type powershell and power-shell as shell type inputs

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -366,7 +366,7 @@ Options:
       --shell <SHELL>
           The shell syntax to use. Infers when missing
 
-          [possible values: bash, zsh, fish, power-shell]
+          [possible values: bash, zsh, fish, powershell]
 
       --fnm-dir <BASE_DIR>
           The root directory of fnm installations
@@ -434,7 +434,7 @@ Options:
       --shell <SHELL>
           The shell syntax to use. Infers when missing
 
-          [possible values: bash, zsh, fish, power-shell]
+          [possible values: bash, zsh, fish, powershell]
 
       --fnm-dir <BASE_DIR>
           The root directory of fnm installations

--- a/src/shell/shell.rs
+++ b/src/shell/shell.rs
@@ -18,6 +18,7 @@ pub enum Shells {
     Bash,
     Zsh,
     Fish,
+    #[clap(name = "powershell", alias = "power-shell")]
     PowerShell,
     #[cfg(windows)]
     Cmd,


### PR DESCRIPTION
supersedes #1225, and fixing the claim in #1224