### PR TITLE
feat: enable --resolve-engines by default. out of experimental phase!

### DIFF
--- a/.changeset/warm-hounds-change.md
+++ b/.changeset/warm-hounds-change.md
@@ -1,0 +1,10 @@
+---
+"fnm": minor
+---
+
+enable `--resolve-engines` by default. out of experimental phase.
+
+to disable it, add a `--resolve-engines=false` flag, and make sure to open an issue describing _why_.
+It might feel like a breaking change but .nvmrc and .node-version have precedence so it should not.
+
+I am all in favor of better experience and I believe supporting engines.node is a good direction.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUST_VERSION: "1.78"
+  RUST_VERSION: "1.81"
 
 jobs:
   fmt:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -59,12 +59,17 @@ Options:
 
           [env: FNM_COREPACK_ENABLED]
 
-      --resolve-engines
+      --resolve-engines [<RESOLVE_ENGINES>]
           Resolve `engines.node` field in `package.json` whenever a `.node-version` or `.nvmrc` file is not present.
-          Experimental: This feature is subject to change.
+          This feature is enabled by default. To disable it, provide `--resolve-engines=false`.
+
           Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+          Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+                  In the future, disabling it might be a no-op, so it's worth knowing any reason to
+                  do that.
 
           [env: FNM_RESOLVE_ENGINES]
+          [possible values: true, false]
 
   -h, --help
           Print help (see a summary with '-h')
@@ -137,12 +142,17 @@ Options:
 
           [env: FNM_COREPACK_ENABLED]
 
-      --resolve-engines
+      --resolve-engines [<RESOLVE_ENGINES>]
           Resolve `engines.node` field in `package.json` whenever a `.node-version` or `.nvmrc` file is not present.
-          Experimental: This feature is subject to change.
+          This feature is enabled by default. To disable it, provide `--resolve-engines=false`.
+
           Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+          Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+                  In the future, disabling it might be a no-op, so it's worth knowing any reason to
+                  do that.
 
           [env: FNM_RESOLVE_ENGINES]
+          [possible values: true, false]
 
   -h, --help
           Print help (see a summary with '-h')
@@ -194,12 +204,17 @@ Options:
 
           [env: FNM_COREPACK_ENABLED]
 
-      --resolve-engines
+      --resolve-engines [<RESOLVE_ENGINES>]
           Resolve `engines.node` field in `package.json` whenever a `.node-version` or `.nvmrc` file is not present.
-          Experimental: This feature is subject to change.
+          This feature is enabled by default. To disable it, provide `--resolve-engines=false`.
+
           Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+          Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+                  In the future, disabling it might be a no-op, so it's worth knowing any reason to
+                  do that.
 
           [env: FNM_RESOLVE_ENGINES]
+          [possible values: true, false]
 
   -h, --help
           Print help (see a summary with '-h')
@@ -267,12 +282,17 @@ Options:
 
           [env: FNM_COREPACK_ENABLED]
 
-      --resolve-engines
+      --resolve-engines [<RESOLVE_ENGINES>]
           Resolve `engines.node` field in `package.json` whenever a `.node-version` or `.nvmrc` file is not present.
-          Experimental: This feature is subject to change.
+          This feature is enabled by default. To disable it, provide `--resolve-engines=false`.
+
           Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+          Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+                  In the future, disabling it might be a no-op, so it's worth knowing any reason to
+                  do that.
 
           [env: FNM_RESOLVE_ENGINES]
+          [possible values: true, false]
 
   -h, --help
           Print help (see a summary with '-h')
@@ -334,12 +354,17 @@ Options:
 
           [env: FNM_COREPACK_ENABLED]
 
-      --resolve-engines
+      --resolve-engines [<RESOLVE_ENGINES>]
           Resolve `engines.node` field in `package.json` whenever a `.node-version` or `.nvmrc` file is not present.
-          Experimental: This feature is subject to change.
+          This feature is enabled by default. To disable it, provide `--resolve-engines=false`.
+
           Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+          Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+                  In the future, disabling it might be a no-op, so it's worth knowing any reason to
+                  do that.
 
           [env: FNM_RESOLVE_ENGINES]
+          [possible values: true, false]
 
   -h, --help
           Print help (see a summary with '-h')
@@ -406,12 +431,17 @@ Options:
 
           [env: FNM_COREPACK_ENABLED]
 
-      --resolve-engines
+      --resolve-engines [<RESOLVE_ENGINES>]
           Resolve `engines.node` field in `package.json` whenever a `.node-version` or `.nvmrc` file is not present.
-          Experimental: This feature is subject to change.
+          This feature is enabled by default. To disable it, provide `--resolve-engines=false`.
+
           Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+          Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+                  In the future, disabling it might be a no-op, so it's worth knowing any reason to
+                  do that.
 
           [env: FNM_RESOLVE_ENGINES]
+          [possible values: true, false]
 
   -h, --help
           Print help (see a summary with '-h')
@@ -468,12 +498,17 @@ Options:
 
           [env: FNM_COREPACK_ENABLED]
 
-      --resolve-engines
+      --resolve-engines [<RESOLVE_ENGINES>]
           Resolve `engines.node` field in `package.json` whenever a `.node-version` or `.nvmrc` file is not present.
-          Experimental: This feature is subject to change.
+          This feature is enabled by default. To disable it, provide `--resolve-engines=false`.
+
           Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+          Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+                  In the future, disabling it might be a no-op, so it's worth knowing any reason to
+                  do that.
 
           [env: FNM_RESOLVE_ENGINES]
+          [possible values: true, false]
 
   -h, --help
           Print help (see a summary with '-h')
@@ -532,12 +567,17 @@ Options:
 
           [env: FNM_COREPACK_ENABLED]
 
-      --resolve-engines
+      --resolve-engines [<RESOLVE_ENGINES>]
           Resolve `engines.node` field in `package.json` whenever a `.node-version` or `.nvmrc` file is not present.
-          Experimental: This feature is subject to change.
+          This feature is enabled by default. To disable it, provide `--resolve-engines=false`.
+
           Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+          Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+                  In the future, disabling it might be a no-op, so it's worth knowing any reason to
+                  do that.
 
           [env: FNM_RESOLVE_ENGINES]
+          [possible values: true, false]
 
   -h, --help
           Print help (see a summary with '-h')
@@ -593,12 +633,17 @@ Options:
 
           [env: FNM_COREPACK_ENABLED]
 
-      --resolve-engines
+      --resolve-engines [<RESOLVE_ENGINES>]
           Resolve `engines.node` field in `package.json` whenever a `.node-version` or `.nvmrc` file is not present.
-          Experimental: This feature is subject to change.
+          This feature is enabled by default. To disable it, provide `--resolve-engines=false`.
+
           Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+          Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+                  In the future, disabling it might be a no-op, so it's worth knowing any reason to
+                  do that.
 
           [env: FNM_RESOLVE_ENGINES]
+          [possible values: true, false]
 
   -h, --help
           Print help (see a summary with '-h')
@@ -656,12 +701,17 @@ Options:
 
           [env: FNM_COREPACK_ENABLED]
 
-      --resolve-engines
+      --resolve-engines [<RESOLVE_ENGINES>]
           Resolve `engines.node` field in `package.json` whenever a `.node-version` or `.nvmrc` file is not present.
-          Experimental: This feature is subject to change.
+          This feature is enabled by default. To disable it, provide `--resolve-engines=false`.
+
           Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+          Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+                  In the future, disabling it might be a no-op, so it's worth knowing any reason to
+                  do that.
 
           [env: FNM_RESOLVE_ENGINES]
+          [possible values: true, false]
 
   -h, --help
           Print help (see a summary with '-h')
@@ -713,12 +763,17 @@ Options:
 
           [env: FNM_COREPACK_ENABLED]
 
-      --resolve-engines
+      --resolve-engines [<RESOLVE_ENGINES>]
           Resolve `engines.node` field in `package.json` whenever a `.node-version` or `.nvmrc` file is not present.
-          Experimental: This feature is subject to change.
+          This feature is enabled by default. To disable it, provide `--resolve-engines=false`.
+
           Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+          Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+                  In the future, disabling it might be a no-op, so it's worth knowing any reason to
+                  do that.
 
           [env: FNM_RESOLVE_ENGINES]
+          [possible values: true, false]
 
   -h, --help
           Print help (see a summary with '-h')
@@ -782,12 +837,17 @@ Options:
 
           [env: FNM_COREPACK_ENABLED]
 
-      --resolve-engines
+      --resolve-engines [<RESOLVE_ENGINES>]
           Resolve `engines.node` field in `package.json` whenever a `.node-version` or `.nvmrc` file is not present.
-          Experimental: This feature is subject to change.
+          This feature is enabled by default. To disable it, provide `--resolve-engines=false`.
+
           Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+          Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+                  In the future, disabling it might be a no-op, so it's worth knowing any reason to
+                  do that.
 
           [env: FNM_RESOLVE_ENGINES]
+          [possible values: true, false]
 
   -h, --help
           Print help (see a summary with '-h')
@@ -798,7 +858,7 @@ Options:
 ```
 Uninstall a Node.js version
 
-> Warning: when providing an alias, it will remove the Node version the alias is pointing to, along with the other aliases that point to the same version.
+> Warning: when providing an alias, it will remove the Node version the alias > is pointing to, along with the other aliases that point to the same version.
 
 Usage: fnm uninstall [OPTIONS] [VERSION]
 
@@ -845,12 +905,17 @@ Options:
 
           [env: FNM_COREPACK_ENABLED]
 
-      --resolve-engines
+      --resolve-engines [<RESOLVE_ENGINES>]
           Resolve `engines.node` field in `package.json` whenever a `.node-version` or `.nvmrc` file is not present.
-          Experimental: This feature is subject to change.
+          This feature is enabled by default. To disable it, provide `--resolve-engines=false`.
+
           Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+          Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+                  In the future, disabling it might be a no-op, so it's worth knowing any reason to
+                  do that.
 
           [env: FNM_RESOLVE_ENGINES]
+          [possible values: true, false]
 
   -h, --help
           Print help (see a summary with '-h')

--- a/e2e/env.test.ts
+++ b/e2e/env.test.ts
@@ -13,7 +13,7 @@ for (const shell of [Bash, Zsh, Fish, PowerShell, WinCmd]) {
         .then(
           shell.redirectOutput(shell.call("fnm", ["env", "--json"]), {
             output: filename,
-          })
+          }),
         )
         .takeSnapshot(shell)
         .execute(shell)
@@ -26,7 +26,7 @@ for (const shell of [Bash, Zsh, Fish, PowerShell, WinCmd]) {
           FNM_LOGLEVEL: "info",
           FNM_MULTISHELL_PATH: expect.any(String),
           FNM_NODE_DIST_MIRROR: expect.any(String),
-          FNM_RESOLVE_ENGINES: "false",
+          FNM_RESOLVE_ENGINES: "true",
           FNM_COREPACK_ENABLED: "false",
           FNM_VERSION_FILE_STRATEGY: "local",
         })

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.78"
+channel = "1.81"
 components = ["rustfmt", "clippy"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -66,7 +66,7 @@ pub enum SubCommand {
     /// Uninstall a Node.js version
     ///
     /// > Warning: when providing an alias, it will remove the Node version the alias
-    /// is pointing to, along with the other aliases that point to the same version.
+    /// > is pointing to, along with the other aliases that point to the same version.
     #[clap(name = "uninstall", bin_name = "uninstall", visible_aliases = &["uni"])]
     Uninstall(commands::uninstall::Uninstall),
 }

--- a/src/commands/ls_remote.rs
+++ b/src/commands/ls_remote.rs
@@ -13,7 +13,10 @@ pub struct LsRemote {
 
     /// Show only LTS versions (optionally filter by LTS codename)  
     #[arg(long)]
-    #[allow(clippy::option_option)]
+    #[expect(
+        clippy::option_option,
+        reason = "clap Option<Option<T>> supports --x and --x=value syntaxes"
+    )]
     lts: Option<Option<String>>,
 
     /// Version sorting order

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,8 +77,12 @@ pub struct FnmConfig {
     corepack_enabled: bool,
 
     /// Resolve `engines.node` field in `package.json` whenever a `.node-version` or `.nvmrc` file is not present.
-    /// Experimental: This feature is subject to change.
+    /// This feature is enabled by default. To disable it, provide `--resolve-engines=false`.
+    ///
     /// Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+    /// Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+    ///         In the future, disabling it might be a no-op, so it's worth knowing any reason to
+    ///         do that.
     #[clap(
         long,
         env = "FNM_RESOLVE_ENGINES",
@@ -86,7 +90,11 @@ pub struct FnmConfig {
         hide_env_values = true,
         verbatim_doc_comment
     )]
-    resolve_engines: bool,
+    #[expect(
+        clippy::option_option,
+        reason = "clap Option<Option<T>> supports --x and --x=value syntaxes"
+    )]
+    resolve_engines: Option<Option<bool>>,
 
     #[clap(skip)]
     directories: Directories,
@@ -102,7 +110,7 @@ impl Default for FnmConfig {
             arch: Arch::default(),
             version_file_strategy: VersionFileStrategy::default(),
             corepack_enabled: false,
-            resolve_engines: false,
+            resolve_engines: None,
             directories: Directories::default(),
         }
     }
@@ -118,7 +126,7 @@ impl FnmConfig {
     }
 
     pub fn resolve_engines(&self) -> bool {
-        self.resolve_engines
+        self.resolve_engines.flatten().unwrap_or(true)
     }
 
     pub fn multishell_path(&self) -> Option<&std::path::Path> {

--- a/src/remote_node_index.rs
+++ b/src/remote_node_index.rs
@@ -62,8 +62,8 @@ pub struct IndexedNodeVersion {
     pub version: Version,
     #[serde(with = "lts_status")]
     pub lts: Option<String>,
-    pub date: chrono::NaiveDate,
-    pub files: Vec<String>,
+    // pub date: chrono::NaiveDate,
+    // pub files: Vec<String>,
 }
 
 /// Prints


### PR DESCRIPTION
- **bump Rust to 1.81**
- **feat: enable --resolve-engines by default. out of experimental phase!**
- **add changeset**

cc @amitdahan for this wonderful feature that is more than 1yr old now
