### PR TITLE
Having alias for install and uninstall commands

### DIFF
--- a/.changeset/gold-onions-lie.md
+++ b/.changeset/gold-onions-lie.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+Having install and uninstall aliases

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,7 +8,7 @@ Usage: fnm [OPTIONS] <COMMAND>
 Commands:
   list-remote  List all remote Node.js versions [aliases: ls-remote]
   list         List all locally installed Node.js versions [aliases: ls]
-  install      Install a new Node.js version
+  install      Install a new Node.js version [aliases: i]
   use          Change Node.js version
   env          Print and set up required environment variables for fnm
   completions  Print shell completions to stdout
@@ -17,7 +17,7 @@ Commands:
   default      Set a version as the default version
   current      Print the current Node.js version
   exec         Run a command within fnm context
-  uninstall    Uninstall a Node.js version
+  uninstall    Uninstall a Node.js version [aliases: uni]
   help         Print this message or the help of the given subcommand(s)
 
 Options:

--- a/e2e/__snapshots__/uninstall.test.ts.snap
+++ b/e2e/__snapshots__/uninstall.test.ts.snap
@@ -2,10 +2,10 @@
 
 exports[`Bash uninstalls a version: Bash 1`] = `
 "set -e
-fnm install 12.0.0
+fnm i 12.0.0
 fnm alias 12.0.0 hello
 ((fnm ls) | grep v12.0.0 || (echo "Expected output to contain v12.0.0" && exit 1)) | grep hello || (echo "Expected output to contain hello" && exit 1)
-fnm uninstall hello
+fnm uni hello
 if [ "$(fnm ls)" != "* system" ]; then
   echo "Expected fnm ls to be * system. Got $(fnm ls)"
   exit 1
@@ -13,10 +13,10 @@ fi"
 `;
 
 exports[`Fish uninstalls a version: Fish 1`] = `
-"fnm install 12.0.0
+"fnm i 12.0.0
 fnm alias 12.0.0 hello
 begin; begin; fnm ls; end | grep v12.0.0; or echo "Expected output to contain v12.0.0" && exit 1; end | grep hello; or echo "Expected output to contain hello" && exit 1
-fnm uninstall hello
+fnm uni hello
 set ____test____ (fnm ls)
 if test "$____test____" != "* system"
   echo "Expected fnm ls to be * system. Got $____test____"
@@ -26,19 +26,19 @@ end"
 
 exports[`PowerShell uninstalls a version: PowerShell 1`] = `
 "$ErrorActionPreference = "Stop"
-fnm install 12.0.0
+fnm i 12.0.0
 fnm alias 12.0.0 hello
 $($__out__ = $($($__out__ = $(fnm ls | Select-String v12.0.0); if ($__out__ -eq $null) { exit 1 } else { $__out__ }) | Select-String hello); if ($__out__ -eq $null) { exit 1 } else { $__out__ })
-fnm uninstall hello
+fnm uni hello
 if ( "$(fnm ls)" -ne "* system" ) { echo "Expected fnm ls to be * system. Got $(fnm ls)"; exit 1 }"
 `;
 
 exports[`Zsh uninstalls a version: Zsh 1`] = `
 "set -e
-fnm install 12.0.0
+fnm i 12.0.0
 fnm alias 12.0.0 hello
 ((fnm ls) | grep v12.0.0 || (echo "Expected output to contain v12.0.0" && exit 1)) | grep hello || (echo "Expected output to contain hello" && exit 1)
-fnm uninstall hello
+fnm uni hello
 if [ "$(fnm ls)" != "* system" ]; then
   echo "Expected fnm ls to be * system. Got $(fnm ls)"
   exit 1

--- a/e2e/uninstall.test.ts
+++ b/e2e/uninstall.test.ts
@@ -6,7 +6,7 @@ for (const shell of [Bash, Zsh, Fish, PowerShell]) {
   describe(shell, () => {
     test(`uninstalls a version`, async () => {
       await script(shell)
-        .then(shell.call("fnm", ["install", "12.0.0"]))
+        .then(shell.call("fnm", ["i", "12.0.0"]))
         .then(shell.call("fnm", ["alias", "12.0.0", "hello"]))
         .then(
           shell.scriptOutputContains(
@@ -14,7 +14,7 @@ for (const shell of [Bash, Zsh, Fish, PowerShell]) {
             "hello"
           )
         )
-        .then(shell.call("fnm", ["uninstall", "hello"]))
+        .then(shell.call("fnm", ["uni", "hello"]))
         .then(
           shell.hasCommandOutput(
             shell.call("fnm", ["ls"]),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,7 @@ pub enum SubCommand {
     LsLocal(commands::ls_local::LsLocal),
 
     /// Install a new Node.js version
-    #[clap(name = "install", bin_name = "install")]
+    #[clap(name = "install", bin_name = "install", visible_aliases = &["i"])]
     Install(commands::install::Install),
 
     /// Change Node.js version
@@ -67,7 +67,7 @@ pub enum SubCommand {
     ///
     /// > Warning: when providing an alias, it will remove the Node version the alias
     /// is pointing to, along with the other aliases that point to the same version.
-    #[clap(name = "uninstall", bin_name = "uninstall")]
+    #[clap(name = "uninstall", bin_name = "uninstall", visible_aliases = &["uni"])]
     Uninstall(commands::uninstall::Uninstall),
 }
 


### PR DESCRIPTION
This change allows a user to run
```bash
fnm i 22.8.0
```
instead of 
```bash
fnm install 22.8.0
```

same for `fnm uni`