### PR TITLE
[feat:] added support for cargo-binstall

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,42 +53,54 @@ jobs:
   build_release:
     runs-on: windows-latest
     name: "Release build for Windows"
+    strategy:
+      matrix:
+        arch: [x86_64, arm64]
     steps:
       - uses: hecrj/setup-rust-action@v1
         with:
           rust-version: ${{env.RUST_VERSION}}
+          targets: ${{ matrix.arch == 'x86_64' && 'x86_64-pc-windows-msvc' || 'aarch64-pc-windows-msvc' }}
       - uses: Swatinem/rust-cache@v2
       - uses: actions/checkout@v4
       - name: Build release binary
         run: cargo build --release
         env:
           RUSTFLAGS: "-C target-feature=+crt-static"
+      - name: Zip the binary
+        run: |
+          mkdir -p target/release
+          zip -j target/release/fnm-${{ matrix.arch }}-pc-windows-msvc.zip target/release/fnm.exe
       - uses: actions/upload-artifact@v4
         with:
-          name: fnm-windows
-          path: target/release/fnm.exe
+          name: fnm-${{ matrix.arch }}-pc-windows-msvc.zip
+          path: target/release/fnm-${{ matrix.arch }}-pc-windows-msvc.zip
 
   build_macos_release:
     runs-on: macos-latest
     name: "Release build for macOS"
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
     steps:
       - uses: hecrj/setup-rust-action@v1
         with:
           rust-version: ${{env.RUST_VERSION}}
+          targets: ${{ matrix.arch == 'x86_64' && 'x86_64-apple-darwin' || 'aarch64-apple-darwin' }}
       - uses: Swatinem/rust-cache@v2
       - uses: actions/checkout@v4
       - name: Build release binary
         run: cargo build --release
-        env:
-          LZMA_API_STATIC: "true"
       - name: Strip binary from debug symbols
         run: strip target/release/fnm
-      - name: List dynamically linked libraries
-        run: otool -L target/release/fnm
+      - name: Zip the binary
+        run: |
+          mkdir -p target/release
+          zip -j target/release/fnm-${{ matrix.arch }}-apple-darwin.zip target/release/fnm
       - uses: actions/upload-artifact@v4
         with:
-          name: fnm-macos
-          path: target/release/fnm
+          name: fnm-${{ matrix.arch }}-apple-darwin.zip
+          path: target/release/fnm-${{ matrix.arch }}-apple-darwin.zip
 
   e2e_macos:
     runs-on: macos-latest
@@ -238,27 +250,33 @@ jobs:
   build_static_linux_binary:
     name: "Build static Linux binary"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64, armv7]
+        rust_target: [x86_64-unknown-linux-musl, aarch64-unknown-linux-musl, armv7-unknown-linux-gnueabihf]
     steps:
       - uses: hecrj/setup-rust-action@v1
         with:
           rust-version: ${{env.RUST_VERSION}}
-          targets: x86_64-unknown-linux-musl
+          targets: ${{ matrix.rust_target }}
       - uses: Swatinem/rust-cache@v2
-        with:
-          key: static-linux-binary
       - name: Install musl tools
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends musl-tools
       - uses: actions/checkout@v4
       - name: Build release binary
-        run: cargo build --release --target x86_64-unknown-linux-musl
+        run: cargo build --release --target ${{ matrix.rust_target }}
       - name: Strip binary from debug symbols
-        run: strip target/x86_64-unknown-linux-musl/release/fnm
+        run: strip target/${{ matrix.rust_target }}/release/fnm
+      - name: Zip the binary
+        run: |
+          mkdir -p target/${{ matrix.rust_target }}/release
+          zip -j target/${{ matrix.rust_target }}/release/fnm-${{ matrix.arch }}-unknown-linux-musl.zip target/${{ matrix.rust_target }}/release/fnm
       - uses: actions/upload-artifact@v4
         with:
-          name: fnm-linux
-          path: target/x86_64-unknown-linux-musl/release/fnm
+          name: fnm-${{ matrix.arch }}-unknown-linux-musl.zip
+          path: target/${{ matrix.rust_target }}/release/fnm-${{ matrix.arch }}-unknown-linux-musl.zip
 
   build_static_arm_binary:
     name: "Build ARM binary"

--- a/binstall.toml
+++ b/binstall.toml
@@ -1,0 +1,36 @@
+[[package]]
+name = "fnm"
+version = "1.37.2" 
+repository = "https://github.com/Schniz/fnm"
+authors = ["Gal Schlezinger <gal@spitfire.co.il>"]
+edition = "2021"
+build = "build.rs"
+license = "GPL-3.0"
+description = "Fast and simple Node.js version manager"
+
+[package.targets]
+
+# Linux (x86_64)
+[[package.targets.linux]]
+url = "https://github.com/Schniz/fnm/releases/download/v1.37.2/fnm-linux.zip"
+checksum = "sha256:439ccbc11e65df970500833e152b896c107f3f3014ea7aaf42213241b403338c"
+
+# macOS (x86_64)
+[[package.targets.mac]]
+url = "https://github.com/Schniz/fnm/releases/download/v1.37.2/fnm-macos.zip"
+checksum = "sha256:a886932043e8c1dee457a733e57edc39df2287d9952a96948155df2a0b6b26b1"
+
+# Windows (x86_64)
+[[package.targets.windows]]
+url = "https://github.com/Schniz/fnm/releases/download/v1.37.2/fnm-windows.zip"
+checksum = "sha256:4f634f9153635e4af26ea96b15c01a28e5e4acc03849a0b51a86be9c70897173"
+
+# ARM32
+[[package.targets.linux-arm]]
+url = "https://github.com/Schniz/fnm/releases/download/v1.37.2/fnm-arm32.zip"
+checksum = "sha256:7047833cdfab2287899dcd686d26b84a2398f43b5aa1cf0f370e0826e89fe039"
+
+# ARM64
+[[package.targets.linux-arm64]]
+url = "https://github.com/Schniz/fnm/releases/download/v1.37.2/fnm-arm64.zip"
+checksum = "sha256:8db196f4bcbb2f27b4742bd5a898ab79d444006d121f888d9201bb3690419763"


### PR DESCRIPTION
This PR updates the CI workflow to:

1. **Consistent Naming Convention**: Standardizes the naming of artifacts produced during the build process across different operating systems and architectures. This new naming convention adheres to the format:
   - For Windows: 
     - `fnm-x86_64-pc-windows-msvc.zip`
     - `fnm-arm64-pc-windows-msvc.zip`
   - For macOS:
     - `fnm-aarch64-apple-darwin.zip`
     - `fnm-x86_64-apple-darwin.zip`
   - For Linux:
     - `fnm-x86_64-unknown-linux-musl.zip`
     - `fnm-arm64-unknown-linux-gnueabihf.zip`

2. Added `binstall.toml` file to support `cargo binstall fnm`


> Note : Currently the `binstall.toml` file is set to target packages in existing release nomenclature like `https://github.com/Schniz/fnm/releases/download/v1.37.2/fnm-macos.zip`


Related Issue : #1280 