### PR TITLE
fix --use-on-cd failing with newly released default of --resolve-engines when `engines` key didn't exist

### DIFF
--- a/.changeset/tasty-flowers-attend.md
+++ b/.changeset/tasty-flowers-attend.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+fix --use-on-cd failing with newly released default of --resolve-engines when `engines` key didn't exist

--- a/e2e/use-on-cd.test.ts
+++ b/e2e/use-on-cd.test.ts
@@ -40,5 +40,19 @@ for (const shell of [Bash, Zsh, Fish, PowerShell, WinCmd]) {
         .then(testNodeVersion(shell, "v12.22.12"))
         .execute(shell)
     })
+
+    test(`doesn't throw on missing env data`, async () => {
+      await mkdir(join(testCwd(), "subdir"), { recursive: true })
+      await writeFile(
+        join(testCwd(), "subdir", "package.json"),
+        JSON.stringify({
+          name: "hello",
+        }),
+      )
+      await script(shell)
+        .then(shell.env({ useOnCd: true, resolveEngines: true }))
+        .then(shell.call("cd", ["subdir"]))
+        .execute(shell)
+    })
   })
 }

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -50,10 +50,9 @@ impl Command for Use {
             .map_err(|source| Error::CantInferVersion { source });
 
         // Swallow the missing version error if `silent_if_unchanged` was provided
-        let requested_version = if self.silent_if_unchanged {
-            return Ok(());
-        } else {
-            requested_version?
+        let requested_version = match (self.silent_if_unchanged, requested_version) {
+            (true, Err(_)) => return Ok(()),
+            (_, v) => v?,
         };
 
         let (message, version_path) = if let UserVersion::Full(Version::Bypassed) =

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -47,7 +47,14 @@ impl Command for Use {
                 VersionFileStrategy::Local => InferVersionError::Local,
                 VersionFileStrategy::Recursive => InferVersionError::Recursive,
             })
-            .map_err(|source| Error::CantInferVersion { source })?;
+            .map_err(|source| Error::CantInferVersion { source });
+
+        // Swallow the missing version error if `silent_if_unchanged` was provided
+        let requested_version = if self.silent_if_unchanged {
+            return Ok(());
+        } else {
+            requested_version?
+        };
 
         let (message, version_path) = if let UserVersion::Full(Version::Bypassed) =
             requested_version


### PR DESCRIPTION
big bug, small fix.
resolves #1308
