### PR TITLE
Update readme to add "-" on powershell command to be the same value as what the cli requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ fnm env --use-on-cd --shell fish | source
 Add the following to the end of your profile file:
 
 ```powershell
-fnm env --use-on-cd --shell powershell | Out-String | Invoke-Expression
+fnm env --use-on-cd --shell power-shell | Out-String | Invoke-Expression
 ```
 
 - For macOS/Linux, the profile is located at `~/.config/powershell/Microsoft.PowerShell_profile.ps1`


### PR DESCRIPTION
the current readme command is: "fnm env --use-on-cd --shell powershell | Out-String | Invoke-Expression"

but copy pasting it show the error: 
```bash
error: invalid value 'powershell' for '--shell <SHELL>'
  [possible values: bash, zsh, fish, power-shell, cmd]

  tip: a similar value exists: 'power-shell'

For more information, try '--help'.
```

changing to "fnm env --use-on-cd --shell power-shell | Out-String | Invoke-Expression" to be able to copy and paste it
