### PR TITLE
fnm env --global: considering if this is a good idea

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -401,6 +401,9 @@ Options:
       --json
           Print JSON instead of shell commands
 
+      --global
+          Have a single Node.js version defined globally. This opts out of the "multishell" solution which allows a Node.js version per shell session. All your shell sessions will share a global Node.js version, and calling `fnm use` will update the global pointer
+
       --log-level <LOG_LEVEL>
           The log level of fnm commands
 
@@ -408,13 +411,13 @@ Options:
           [default: info]
           [possible values: quiet, error, info]
 
-      --use-on-cd
-          Print the script to change Node versions every directory change
-
       --arch <ARCH>
           Override the architecture of the installed Node binary. Defaults to arch of fnm binary
 
           [env: FNM_ARCH]
+
+      --use-on-cd
+          Print the script to change Node versions every directory change
 
       --version-file-strategy <VERSION_FILE_STRATEGY>
           A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a version, or when `--use-on-cd` is configured on evaluation

--- a/src/config.rs
+++ b/src/config.rs
@@ -168,6 +168,10 @@ impl FnmConfig {
         self.directories.multishell_storage()
     }
 
+    pub fn current_global_version_path(&self) -> std::path::PathBuf {
+        self.base_dir_with_default().join("current")
+    }
+
     #[cfg(test)]
     pub fn with_base_dir(mut self, base_dir: Option<std::path::PathBuf>) -> Self {
         self.base_dir = base_dir;

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -27,3 +27,28 @@ pub fn remove_symlink_dir<P: AsRef<Path>>(path: P) -> std::io::Result<()> {
 pub fn shallow_read_symlink<P: AsRef<Path>>(path: P) -> std::io::Result<std::path::PathBuf> {
     std::fs::read_link(path)
 }
+
+/// Creates a symlink into a temporary directory,
+/// then renames the temporary directory to the target.
+///
+/// This is required as symlinking doesn't override existing
+/// symlinks.
+/// The naive solution is to delete, and then symlink, but that can create
+/// a race condition in the filesystem.
+pub fn two_phase_symlink(
+    source: &std::path::Path,
+    target: &std::path::Path,
+) -> Result<(), TwoPhaseSymlinkError> {
+    let temp = tempfile::tempdir().map_err(TwoPhaseSymlinkError::CreatingTempSymlink)?;
+    let temp_path = temp.path().join("temp");
+    symlink_dir(source, &temp_path).map_err(TwoPhaseSymlinkError::CreatingTempSymlink)?;
+    std::fs::rename(&temp_path, target).map_err(TwoPhaseSymlinkError::Renaming)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TwoPhaseSymlinkError {
+    #[error("Can't create temporary symlink for two phase symlink: {0}")]
+    CreatingTempSymlink(#[source] std::io::Error),
+    #[error("Can't create a symlink in the target directory: {0}")]
+    Renaming(#[source] std::io::Error),
+}


### PR DESCRIPTION
technically i think that i can just mutate the 'default' alias instead. because now that i think about it,
it makes 0 sense to set current to 'default' every time a new shell is opened. so current _is_ default.
