### PR TITLE
fix: set correct INSTALL_DIR for brew installation

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -87,6 +87,7 @@ set_filename() {
 download_fnm() {
   if [ "$USE_HOMEBREW" = "true" ]; then
     brew install fnm
+    INSTALL_DIR="$(brew --prefix fnm)/bin"
   else
     if [ "$RELEASE" = "latest" ]; then
       URL="https://github.com/Schniz/fnm/releases/latest/download/$FILENAME.zip"
@@ -173,7 +174,9 @@ setup_shell() {
       echo '# fnm'
       echo 'FNM_PATH="'"$INSTALL_DIR"'"'
       echo 'if [ -d "$FNM_PATH" ]; then'
-      echo '  export PATH="'$INSTALL_DIR':$PATH"'
+      if [ "$USE_HOMEBREW" != "true" ]; then
+        echo '  export PATH="$FNM_PATH:$PATH"'
+      fi
       echo '  eval "`fnm env`"'
       echo 'fi'
     } | tee -a "$CONF_FILE"
@@ -187,7 +190,9 @@ setup_shell() {
       echo '# fnm'
       echo 'set FNM_PATH "'"$INSTALL_DIR"'"'
       echo 'if [ -d "$FNM_PATH" ]'
-      echo '  set PATH "$FNM_PATH" $PATH'
+      if [ "$USE_HOMEBREW" != "true" ]; then
+        echo '  set PATH "$FNM_PATH" $PATH'
+      fi
       echo '  fnm env | source'
       echo 'end'
     } | tee -a "$CONF_FILE"
@@ -205,7 +210,9 @@ setup_shell() {
       echo '# fnm'
       echo 'FNM_PATH="'"$INSTALL_DIR"'"'
       echo 'if [ -d "$FNM_PATH" ]; then'
-      echo '  export PATH="$FNM_PATH:$PATH"'
+      if [ "$USE_HOMEBREW" != "true" ]; then
+        echo '  export PATH="$FNM_PATH:$PATH"'
+      fi
       echo '  eval "`fnm env`"'
       echo 'fi'
     } | tee -a "$CONF_FILE"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ curl -fsSL https://fnm.vercel.app/install | bash -s -- --skip-shell
 
 Set a custom directory for fnm to be installed. The default is `$XDG_DATA_HOME/fnm` (if `$XDG_DATA_HOME` is not defined it falls back to `$HOME/.local/share/fnm` on linux and `$HOME/Library/Application Support/fnm` on MacOS).
 
+> **Note:** On macOS, this option is only meaningful when using `--force-install` since Homebrew is the default installation method.
+
 `--skip-shell`
 
 Skip appending shell specific loader to shell config file, based on the current user shell, defined in `$SHELL`. e.g. for Bash, `$HOME/.bashrc`. `$HOME/.zshrc` for Zsh. For Fish - `$HOME/.config/fish/conf.d/fnm.fish`


### PR DESCRIPTION
fixes #824, #1190, #1194, #1237, #1279 

On macOS, when you install `fnm` using Homebrew, the installation directory ends up being something like `/usr/local/opt/fnm` or `/opt/homebrew/opt/fnm` instead of `$HOME/.fnm`, `$XDG_DATA_HOME/fnm`, `$HOME/Library/Application Support/fnm`.

I updated `INSTALL_DIR` to match the correct location for Homebrew installations. Also, since Homebrew takes care of the `PATH` automatically, `export PATH` step is removed.