### PR TITLE
Initialize fnm only in interactive Fish sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ eval "$(fnm env --use-on-cd --shell zsh)"
 Create `~/.config/fish/conf.d/fnm.fish` and add this line to it:
 
 ```fish
-fnm env --use-on-cd --shell fish | source
+status is-interactive && fnm env --use-on-cd --shell fish | source
 ```
 
 #### PowerShell


### PR DESCRIPTION
Prevents unnecessary fnm initialization in non-interactive sessions by adding a status check before executing the fnm environment setup.

This ensures fnm is not initialized when selecting commands from Fish history, improving performance by avoiding redundant executions. Additionally, it prevents fnm notifications from being inserted into the command line during history selection as Fish executes config snippets in non-interactive mode in that context.
