### PR TITLE
feat(list-remote): introduce `--latest-lts` option

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -127,6 +127,9 @@ Options:
 
           [env: FNM_ARCH]
 
+      --latest-lts
+          Show the latest version of each LTS
+
       --version-file-strategy <VERSION_FILE_STRATEGY>
           A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a version, or when `--use-on-cd` is configured on evaluation
 

--- a/src/remote_node_index.rs
+++ b/src/remote_node_index.rs
@@ -57,7 +57,7 @@ mod lts_status {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct IndexedNodeVersion {
     pub version: Version,
     #[serde(with = "lts_status")]


### PR DESCRIPTION
This PR introduces the `--latest-lts` option to the `list-remote` command, which allows you to show the latest version of each LTS.

closes #1373 

> I'm a rust noob, any advice is welcomed:(