### PR TITLE
Add `--silent` option for use with `fnm env`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,6 +46,10 @@ repo/packages/my-package$ fnm use
 error: Can't find version in dotfiles. Please provide a version manually to the command.
 ```
 
+### `--silent`
+
+Suppress "Using Node Version..." message when changing versions with --use-on-cd
+
 ### `--corepack-enabled`
 
 **🧪 Experimental**

--- a/e2e/shellcode/shells/cmdEnv.ts
+++ b/e2e/shellcode/shells/cmdEnv.ts
@@ -7,6 +7,7 @@ type EnvConfig = {
   corepackEnabled: boolean
   resolveEngines: boolean
   nodeDistMirror: string
+  silent: boolean
 }
 export type HasEnv = { env(cfg: Partial<EnvConfig>): ScriptLine }
 
@@ -18,6 +19,7 @@ function stringify(envConfig: Partial<EnvConfig> = {}) {
     resolveEngines,
     executableName = "fnm",
     nodeDistMirror,
+    silent,
   } = envConfig
   return [
     `${executableName} env`,
@@ -26,6 +28,7 @@ function stringify(envConfig: Partial<EnvConfig> = {}) {
     corepackEnabled && "--corepack-enabled",
     resolveEngines && `--resolve-engines`,
     nodeDistMirror && `--node-dist-mirror=${JSON.stringify(nodeDistMirror)}`,
+    silent && "--silent",
   ]
     .filter(Boolean)
     .join(" ")

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -24,6 +24,9 @@ pub struct Env {
     /// Print the script to change Node versions every directory change
     #[clap(long)]
     use_on_cd: bool,
+    /// Suppress "Using Node Version..." message when changing versions with --use-on-cd
+    #[clap(long)]
+    silent: bool,
 }
 
 fn generate_symlink_path() -> String {
@@ -89,6 +92,7 @@ impl Command for Env {
             ),
             ("FNM_RESOLVE_ENGINES", bool_as_str(config.resolve_engines())),
             ("FNM_ARCH", config.arch.as_str()),
+            ("FNM_SILENT", bool_as_str(config.silent())),
         ];
 
         if self.json {

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -95,7 +95,7 @@ impl Command for Use {
             }
         };
 
-        if !self.silent_if_unchanged || will_version_change(&version_path, config) {
+        if !config.silent() && (!self.silent_if_unchanged || will_version_change(&version_path, config)) {
             outln!(config, Info, "{}", message);
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,6 +76,15 @@ pub struct FnmConfig {
     )]
     corepack_enabled: bool,
 
+    /// Suppress "Using Node Version..." message when changing versions with --use-on-cd
+    #[clap(
+        long,
+        env = "FNM_SILENT",
+        global = true,
+        hide_env_values = true
+    )]
+    silent: bool,
+
     /// Resolve `engines.node` field in `package.json` whenever a `.node-version` or `.nvmrc` file is not present.
     /// This feature is enabled by default. To disable it, provide `--resolve-engines=false`.
     ///
@@ -110,6 +119,7 @@ impl Default for FnmConfig {
             arch: Arch::default(),
             version_file_strategy: VersionFileStrategy::default(),
             corepack_enabled: false,
+            silent: false,
             resolve_engines: None,
             directories: Directories::default(),
         }
@@ -123,6 +133,10 @@ impl FnmConfig {
 
     pub fn corepack_enabled(&self) -> bool {
         self.corepack_enabled
+    }
+
+    pub fn silent(&self) -> bool {
+        self.silent
     }
 
     pub fn resolve_engines(&self) -> bool {


### PR DESCRIPTION
This makes it so you can add `--silent` to your shell config and it won't display the "Using Node Version..." message.