### PR TITLE
Add Elvish shell integration

### DIFF
--- a/e2e/shellcode/shells.ts
+++ b/e2e/shellcode/shells.ts
@@ -40,6 +40,22 @@ export const Zsh = {
   ...cmdInSubShell.zsh,
 }
 
+export const Elvish = {
+  ...define<Shell>({
+    binaryName: () => "elvish",
+    currentlySupported: () => true,
+    name: () => "Elvish",
+    launchArgs: () => [],
+    escapeText: (x) => x,
+  }),
+  ...cmdEnv.elvish,
+  ...cmdCall.all,
+  ...redirectOutput.bash,
+  ...cmdExpectCommandOutput.elvish,
+  ...cmdHasOutputContains.elvish,
+  ...cmdInSubShell.elvish,
+}
+
 export const Fish = {
   ...define<Shell>({
     binaryName: () => "fish",

--- a/e2e/shellcode/shells/cmdEnv.ts
+++ b/e2e/shellcode/shells/cmdEnv.ts
@@ -38,6 +38,9 @@ export const cmdEnv = {
   fish: define<HasEnv>({
     env: (envConfig) => `${stringify(envConfig)} | source`,
   }),
+  elvish: define<HasEnv>({
+    env: (envConfig) => `eval ${stringify(envConfig)}`
+  }),
   powershell: define<HasEnv>({
     env: (envConfig) =>
       `${stringify(envConfig)} | Out-String | Invoke-Expression`,

--- a/e2e/shellcode/shells/expect-command-output.ts
+++ b/e2e/shellcode/shells/expect-command-output.ts
@@ -20,6 +20,16 @@ export const cmdExpectCommandOutput = {
       `
     },
   }),
+  elvish: define<HasExpectCommandOutput>({
+    hasCommandOutput(script, output, message) {
+      return dedent`
+      set ____test____ (${script})
+      	if (!= ____test____ "${output}") {
+	      	echo "Expected ${message} to be ${output}. Got $(${script})"
+      	}
+			`
+    },
+  }),
   fish: define<HasExpectCommandOutput>({
     hasCommandOutput(script, output, message) {
       return dedent`

--- a/e2e/shellcode/shells/output-contains.ts
+++ b/e2e/shellcode/shells/output-contains.ts
@@ -15,6 +15,11 @@ export const cmdHasOutputContains = {
       return `begin; ${script}; end | grep ${substring}; or echo "Expected output to contain ${substring}" && exit 1`
     },
   }),
+  elvish: define<HasOutputContains>({
+    scriptOutputContains: (script, substring) => {
+      return `try { ${script} | grep ${substring} } catch e { echo "Expected output to contain ${substring}"}; exit 1`
+    },
+  }),
   powershell: define<HasOutputContains>({
     scriptOutputContains: (script, substring) => {
       const inner: string = `${script} | Select-String ${substring}`

--- a/e2e/shellcode/shells/sub-shell.ts
+++ b/e2e/shellcode/shells/sub-shell.ts
@@ -13,6 +13,9 @@ export const cmdInSubShell = {
   fish: define<HasInSubShell>({
     inSubShell: (script) => `fish -c ${quote([script])}`,
   }),
+  elvish: define<HasInSubShell>({
+    inSubShell: (script) => `elvish -c ${quote([script])}`
+  }),
   powershell: define<HasInSubShell>({
     inSubShell: (script) =>
       `echo '${script.replace(/'/g, "\\'")}' | pwsh -NoProfile`,

--- a/src/shell/elvish.rs
+++ b/src/shell/elvish.rs
@@ -1,0 +1,59 @@
+use crate::version_file_strategy::VersionFileStrategy;
+
+use super::shell::Shell;
+use indoc::formatdoc;
+use std::path::Path;
+
+#[derive(Debug)]
+pub struct Elvish;
+
+impl Shell for Elvish {
+    fn to_clap_shell(&self) -> clap_complete::Shell {
+        clap_complete::Shell::Elvish
+    }
+
+    fn path(&self, path: &Path) -> anyhow::Result<String> {
+        let path = path
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("Can't convert path to string"))?;
+        let path =
+            super::windows_compat::maybe_fix_windows_path(path).unwrap_or_else(|| path.to_string());
+        Ok(format!("set-env PATH {path:?}:$E:PATH;"))
+    }
+
+    fn set_env_var(&self, name: &str, value: &str) -> String {
+        format!("set-env {name} {value:?};")
+    }
+
+    fn use_on_cd(&self, config: &crate::config::FnmConfig) -> anyhow::Result<String> {
+        let version_file_exists_condition = if config.resolve_engines() {
+            "test -f .node-version -o -f .nvmrc -o -f package.json"
+        } else {
+            "test -f .node-version -o -f .nvmrc"
+        };
+        let autoload_hook = match config.version_file_strategy() {
+            VersionFileStrategy::Local => formatdoc!(
+                r#"
+	                try {{
+		                {version_file_exists_condition}
+	                }} catch e {{
+
+	                }} else {{
+		                fnm use --silent-if-unchanged
+	                }}
+                "#,
+                version_file_exists_condition = version_file_exists_condition,
+            ),
+            VersionFileStrategy::Recursive => String::from(r"fnm use --silent-if-unchanged"),
+        };
+        Ok(formatdoc!(
+            r#"
+							fn _fnm_autoload_hook {{
+							{autoload_hook}
+							}}
+							set after-chdir = [{{|dir| {autoload_hook} }}]
+            "#,
+            autoload_hook = autoload_hook
+        ))
+    }
+}

--- a/src/shell/elvish.rs
+++ b/src/shell/elvish.rs
@@ -34,13 +34,12 @@ impl Shell for Elvish {
         let autoload_hook = match config.version_file_strategy() {
             VersionFileStrategy::Local => formatdoc!(
                 r#"
-	                try {{
-		                {version_file_exists_condition}
-	                }} catch e {{
-
-	                }} else {{
-		                fnm use --silent-if-unchanged
-	                }}
+                try {{
+                  {version_file_exists_condition}
+                }} catch e {{
+                }} else {{
+                  fnm use --silent-if-unchanged
+                }}
                 "#,
                 version_file_exists_condition = version_file_exists_condition,
             ),
@@ -48,10 +47,7 @@ impl Shell for Elvish {
         };
         Ok(formatdoc!(
             r#"
-							fn _fnm_autoload_hook {{
-							{autoload_hook}
-							}}
-							set after-chdir = [{{|dir| {autoload_hook} }}]
+            set after-chdir = [{{|dir| {autoload_hook} }}]
             "#,
             autoload_hook = autoload_hook
         ))

--- a/src/shell/infer/mod.rs
+++ b/src/shell/infer/mod.rs
@@ -8,11 +8,12 @@ pub use self::unix::infer_shell;
 pub use self::windows::infer_shell;
 
 fn shell_from_string(shell: &str) -> Option<Box<dyn super::Shell>> {
-    use super::{Bash, Fish, PowerShell, WindowsCmd, Zsh};
+    use super::{Bash, Elvish, Fish, PowerShell, WindowsCmd, Zsh};
     match shell {
         "sh" | "bash" => return Some(Box::from(Bash)),
         "zsh" => return Some(Box::from(Zsh)),
         "fish" => return Some(Box::from(Fish)),
+        "elvish" => return Some(Box::from(Elvish)),
         "pwsh" | "powershell" => return Some(Box::from(PowerShell)),
         "cmd" => return Some(Box::from(WindowsCmd)),
         cmd_name => log::debug!("binary is not a supported shell: {:?}", cmd_name),

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1,4 +1,5 @@
 mod bash;
+mod elvish;
 mod fish;
 mod infer;
 mod powershell;
@@ -10,6 +11,7 @@ mod shell;
 mod windows_compat;
 
 pub use bash::Bash;
+pub use elvish::Elvish;
 pub use fish::Fish;
 pub use infer::infer_shell;
 pub use powershell::PowerShell;

--- a/src/shell/shell.rs
+++ b/src/shell/shell.rs
@@ -18,6 +18,7 @@ pub enum Shells {
     Bash,
     Zsh,
     Fish,
+    Elvish,
     #[clap(name = "powershell", alias = "power-shell")]
     PowerShell,
     #[cfg(windows)]
@@ -30,6 +31,7 @@ impl Display for Shells {
             Shells::Bash => f.write_str("bash"),
             Shells::Zsh => f.write_str("zsh"),
             Shells::Fish => f.write_str("fish"),
+            Shells::Elvish => f.write_str("elvish"),
             Shells::PowerShell => f.write_str("powershell"),
             #[cfg(windows)]
             Shells::Cmd => f.write_str("cmd"),
@@ -43,6 +45,7 @@ impl From<Shells> for Box<dyn Shell> {
             Shells::Zsh => Box::from(super::zsh::Zsh),
             Shells::Bash => Box::from(super::bash::Bash),
             Shells::Fish => Box::from(super::fish::Fish),
+            Shells::Elvish => Box::from(super::elvish::Elvish),
             Shells::PowerShell => Box::from(super::powershell::PowerShell),
             #[cfg(windows)]
             Shells::Cmd => Box::from(super::windows_cmd::WindowsCmd),


### PR DESCRIPTION
Elvish is a scripting language and interactive shell for Linux, BSD, MacOS and Windows. I decided to add elvish integration because found that it is somewhat similar to fish shell and it would be useful for elvish users to be able to use `--use-on-cd` feature of `fnm`.

```elvish
try {{
  {version_file_exists_condition}
}} catch e {{
}} else {{
  fnm use --silent-if-unchanged
}}
```

Reason for this strange type of checking in `src/shell/elvish.rs` is that there is no way in elvish to view the exit code of the last command, so the best IMO way to do this is by catching error if `test` exits with 1 code. 
```elvish
set after-chdir = [{{|dir| {autoload_hook} }}]
```
Also, elvish has `after-dir` hook, which automatically runs the `autoload_hook` on directory change.

I tested it on Linux x86_64, hopefully it will work on Windows and MacOS too.