### PR TITLE
Fix fnm setup command in PowerShell profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ fnm env --use-on-cd --shell fish | source
 Add the following to the end of your profile file:
 
 ```powershell
-fnm env --use-on-cd --shell powershell | Out-String | Invoke-Expression
+fnm env --use-on-cd --shell power-shell | Out-String | Invoke-Expression
 ```
 
 - For macOS/Linux, the profile is located at `~/.config/powershell/Microsoft.PowerShell_profile.ps1`


### PR DESCRIPTION
While setting up the environment on Windows, I noticed that the command provided for adding fnm to the PowerShell profile was incorrect. fnm doesn't recognize --shell powershell — the correct value is --shell power-shell.

This PR updates the documentation to fix the command and ensure proper configuration for Windows users.