### PR TITLE
feat(install): fix setup_shell function for brew users

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -4,6 +4,7 @@ set -e
 
 RELEASE="latest"
 OS="$(uname -s)"
+USE_HOMEBREW="false"
 
 case "${OS}" in
    MINGW* | Win*) OS="Windows" ;;
@@ -168,29 +169,45 @@ setup_shell() {
     CONF_FILE=${ZDOTDIR:-$HOME}/.zshrc
     ensure_containing_dir_exists "$CONF_FILE"
     echo "Installing for Zsh. Appending the following to $CONF_FILE:"
-    {
-      echo ''
-      echo '# fnm'
-      echo 'FNM_PATH="'"$INSTALL_DIR"'"'
-      echo 'if [ -d "$FNM_PATH" ]; then'
-      echo '  export PATH="'$INSTALL_DIR':$PATH"'
-      echo '  eval "`fnm env`"'
-      echo 'fi'
-    } | tee -a "$CONF_FILE"
+    if [ "$USE_HOMEBREW" = "false" ]; then
+      {
+        echo ''
+        echo '# fnm'
+        echo 'FNM_PATH="'"$INSTALL_DIR"'"'
+        echo 'if [ -d "$FNM_PATH" ]; then'
+        echo '  export PATH="'$INSTALL_DIR':$PATH"'
+        echo '  eval "`fnm env`"'
+        echo 'fi'
+      } | tee -a "$CONF_FILE"
+    else
+      {
+        echo ''
+        echo '# fnm'
+        echo 'eval "`fnm env`"'
+      } | tee -a "$CONF_FILE"
+    fi
 
   elif [ "$CURRENT_SHELL" = "fish" ]; then
     CONF_FILE=$HOME/.config/fish/conf.d/fnm.fish
     ensure_containing_dir_exists "$CONF_FILE"
     echo "Installing for Fish. Appending the following to $CONF_FILE:"
-    {
-      echo ''
-      echo '# fnm'
-      echo 'set FNM_PATH "'"$INSTALL_DIR"'"'
-      echo 'if [ -d "$FNM_PATH" ]'
-      echo '  set PATH "$FNM_PATH" $PATH'
-      echo '  fnm env | source'
-      echo 'end'
-    } | tee -a "$CONF_FILE"
+    if [ "$USE_HOMEBREW" = "false" ]; then
+      {
+        echo ''
+        echo '# fnm'
+        echo 'set FNM_PATH "'"$INSTALL_DIR"'"'
+        echo 'if [ -d "$FNM_PATH" ]'
+        echo '  set PATH "$FNM_PATH" $PATH'
+        echo '  fnm env | source'
+        echo 'end'
+      } | tee -a "$CONF_FILE"
+    else
+      {
+        echo ''
+        echo '# fnm'
+        echo 'fnm env | source'
+      } | tee -a "$CONF_FILE"
+    fi
 
   elif [ "$CURRENT_SHELL" = "bash" ]; then
     if [ "$OS" = "Darwin" ]; then
@@ -200,15 +217,23 @@ setup_shell() {
     fi
     ensure_containing_dir_exists "$CONF_FILE"
     echo "Installing for Bash. Appending the following to $CONF_FILE:"
-    {
-      echo ''
-      echo '# fnm'
-      echo 'FNM_PATH="'"$INSTALL_DIR"'"'
-      echo 'if [ -d "$FNM_PATH" ]; then'
-      echo '  export PATH="$FNM_PATH:$PATH"'
-      echo '  eval "`fnm env`"'
-      echo 'fi'
-    } | tee -a "$CONF_FILE"
+    if [ "$USE_HOMEBREW" = "false" ]; then
+      {
+        echo ''
+        echo '# fnm'
+        echo 'FNM_PATH="'"$INSTALL_DIR"'"'
+        echo 'if [ -d "$FNM_PATH" ]; then'
+        echo '  export PATH="$FNM_PATH:$PATH"'
+        echo '  eval "`fnm env`"'
+        echo 'fi'
+      } | tee -a "$CONF_FILE"
+    else
+      {
+        echo ''
+        echo '# fnm'
+        echo 'eval "`fnm env`"'
+      } | tee -a "$CONF_FILE"
+    fi
 
   else
     echo "Could not infer shell type. Please set up manually."

--- a/.github/workflows/installation_script.yml
+++ b/.github/workflows/installation_script.yml
@@ -1,5 +1,6 @@
 name: Installation script
-on: 
+on:
+  workflow_dispatch:
   pull_request:
     paths:
       - .ci/install.sh


### PR DESCRIPTION
# Fixing the install script for brew users

## Issue
When installing `fnm` via Homebrew, the binary gets installed to Homebrew's directory structure rather than the default `INSTALL_DIR`. Additionally, Homebrew automatically adds `fnm` to the `PATH`, making our manual `PATH` manipulation unnecessary and potentially problematic.

## Changes
- Set a `USE_HOMEBREW` flag to false by default
- Updated shell configuration for all supported shells (zsh, fish, bash) to handle Homebrew installations differently:
  - For Homebrew installations: only add `eval "$(fnm env)"` to shell config files
  - For direct installations: maintain existing behavior with `PATH` manipulation
- Simplify shell configuration when Homebrew is used, avoiding redundant `PATH` modifications

These changes ensure `fnm` works correctly regardless of installation method, while respecting the environment setup performed by package managers.

Fix #824 #1190 #1194 #1237 #1279 #1376 
