### PR TITLE
Ignore closed pipe error from the shell. 

### DIFF
--- a/src/log_level.rs
+++ b/src/log_level.rs
@@ -51,7 +51,13 @@ impl Display for LogLevel {
 macro_rules! outln {
     ($config:ident, $level:path, $($expr:expr),+) => {{
         use $crate::log_level::LogLevel::*;
-        writeln!($config.log_level().writer_for($level), $($expr),+).expect("Can't write output");
+        use std::io::ErrorKind;
+        let result = writeln!($config.log_level().writer_for($level), $($expr),+);
+        if let Err(e) = result {
+            if e.kind() != ErrorKind::BrokenPipe {
+                panic!("Failed to write output: {}", e);
+            }
+        }
     }}
 }
 


### PR DESCRIPTION
Some shells (fish 4) seem to close the pipe fast, so the use command is getting an error back even though the message writes successfully. Basically get an assert any time you cd into a directory with a .node-version, which is not ideal.