### PR TITLE
Fix `powershell` typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Where `<SHELL>` can be one of the supported shells:
 - `bash`
 - `zsh`
 - `fish`
-- `powershell`
+- `power-shell`
 
 Please follow your shell instructions to install them.
 
@@ -177,7 +177,7 @@ fnm env --use-on-cd --shell fish | source
 Add the following to the end of your profile file:
 
 ```powershell
-fnm env --use-on-cd --shell powershell | Out-String | Invoke-Expression
+fnm env --use-on-cd --shell power-shell | Out-String | Invoke-Expression
 ```
 
 - For macOS/Linux, the profile is located at `~/.config/powershell/Microsoft.PowerShell_profile.ps1`


### PR DESCRIPTION
On fnm, shell possible values are: bash, zsh, fish, power-shell, cmd.

This PR update README.md to reflect this.