### PR TITLE
Update README.md. Fix power-shell command

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ fnm env --use-on-cd --shell fish | source
 Add the following to the end of your profile file:
 
 ```powershell
-fnm env --use-on-cd --shell powershell | Out-String | Invoke-Expression
+fnm env --use-on-cd --shell power-shell | Out-String | Invoke-Expression
 ```
 
 - For macOS/Linux, the profile is located at `~/.config/powershell/Microsoft.PowerShell_profile.ps1`


### PR DESCRIPTION
Updated command for PowerShell.
Reasoning:
```
$fnm env --use-on-cd --shell powershell | Out-String | Invoke-Expression
error: invalid value 'powershell' for '--shell <SHELL>'
  [possible values: bash, zsh, fish, power-shell, cmd]

  tip: a similar value exists: 'power-shell'

For more information, try '--help'.
Invoke-Expression : Cannot bind argument to parameter 'Command' because it is an empty string.
At line:1 char:55
+ ... m env --use-on-cd --shell powershell | Out-String | Invoke-Expression
+                                                         ~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:PSObject) [Invoke-Expression], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationErrorEmptyStringNotAllowed,Microsoft.PowerShell.Commands.InvokeExpressionCommand
```

`fnm env --use-on-cd --shell power-shell | Out-String | Invoke-Expression` worked fine. Tested on Windows 11

```
$PSVersionTable.PSVersion

Major  Minor  Build  Revision
-----  -----  -----  --------
5      1      22621  4391
```