### PR TITLE
fix(shell): actually allow `powershell` and `power-shell` as shell type inputs

### DIFF
--- a/.changeset/crazy-rivers-rest.md
+++ b/.changeset/crazy-rivers-rest.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+actually allow both `powershell` and `power-shell` as shell type inputs

--- a/src/shell/shell.rs
+++ b/src/shell/shell.rs
@@ -18,7 +18,7 @@ pub enum Shells {
     Bash,
     Zsh,
     Fish,
-    #[clap(name = "powershell", alias = "power-shell")]
+    #[clap(name = "power-shell", alias = "powershell")]
     PowerShell,
     #[cfg(windows)]
     Cmd,


### PR DESCRIPTION
fixes #1431
fixes #1346
fixes #1040

related to #1264

supersedes #1411, #1421, #1423