### PR TITLE
fix: set correct PATH for fish shell

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -190,9 +190,7 @@ setup_shell() {
       echo '# fnm'
       echo 'set FNM_PATH "'"$INSTALL_DIR"'"'
       echo 'if [ -d "$FNM_PATH" ]'
-      if [ "$USE_HOMEBREW" != "true" ]; then
-        echo '  set PATH "$FNM_PATH" $PATH'
-      fi
+      echo '  set PATH "$FNM_PATH" $PATH'
       echo '  fnm env | source'
       echo 'end'
     } | tee -a "$CONF_FILE"


### PR DESCRIPTION
Direct quote from https://fishshell.com/docs/current/index.html#configuration ...

> `.fish` scripts in `~/.config/fish/conf.d/` are also automatically executed before `config.fish`.

`brew` initializes itself via `config.fish` file. So, the `PATH` doesn't have `/opt/homebrew/bin` when `~/.config/fish/conf.d/fnm.fish` is executed, resulting in the following error...

```
fish: Unknown command: fnm
~/.config/fish/conf.d/fnm.fish (line 5): 
  fnm env | source
  ^~^
from sourcing file ~/.config/fish/conf.d/fnm.fish
	called on line 253 of file /usr/local/share/fish/config.fish
from sourcing file /usr/local/share/fish/config.fish
	called during startup
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
```

This pull request sets correct PATH to initialize `fnm` on fish shell.