### PR TITLE
fix(use): compare requested version against resolved symlink when --silent-if-unchanged is enabled

### DIFF
--- a/.changeset/olive-deer-travel.md
+++ b/.changeset/olive-deer-travel.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+Fix alias `use` when `--silent-if-unchanged` is set

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -66,19 +66,23 @@ impl Command for Use {
         } else if let Some(alias_name) = requested_version.alias_name() {
             let alias_path = config.aliases_dir().join(&alias_name);
             let system_path = system_version::path();
-            if matches!(fs::shallow_read_symlink(&alias_path), Ok(shallow_path) if shallow_path == system_path)
-            {
-                let message = format!(
-                    "Bypassing fnm: using {} node",
-                    system_version::display_name().cyan()
-                );
-                (message, system_path)
-            } else if alias_path.exists() {
-                let message = format!("Using Node for alias {}", alias_name.cyan());
-                (message, alias_path)
-            } else {
-                install_new_version(requested_version, config, self.install_if_missing)?;
-                return Ok(());
+            match fs::shallow_read_symlink(&alias_path) {
+                Ok(resolved_alias) => {
+                    if resolved_alias == system_path {
+                        let message = format!(
+                            "Bypassing fnm: using {} node",
+                            system_version::display_name().cyan()
+                        );
+                        (message, system_path)
+                    } else {
+                        let message = format!("Using Node for alias {}", alias_name.cyan());
+                        (message, resolved_alias)
+                    }
+                }
+                Err(_) => {
+                    install_new_version(requested_version, config, self.install_if_missing)?;
+                    return Ok(());
+                }
             }
         } else {
             let current_version = requested_version.to_version(&all_versions, config);


### PR DESCRIPTION
# Problem

When _using_ a version by `alias` and, setting the `--silent-if-unchanged` flag you don't get a truly _silent_ execution. Running several times with the same option and version should stop producing output after the first invocation:

```console
$ fnm use --silent-if-unchanged default
Using Node for alias default
$ fnm use --silent-if-unchanged default
Using Node for alias default
$ fnm use --silent-if-unchanged default
Using Node for alias default
$ fnm use --silent-if-unchanged default
Using Node for alias default
```
--- 
# Change
 
 The path sent [to comparison](https://github.com/Schniz/fnm/blob/1ebc90decf58c2176dcbd4f8ac00ecb3adb1de12/src/commands/use.rs#L78) is, as I understand, a symlink. Following it and returning that instead seems to be just enough to fix the above issue.
 
 ---
 # Disclaimer
 
 I don't have any means to test this other than:
 
```
$ cargo clean && cargo run -- use --silent-if-unchanged default
```

If there is any other way I can test this (without introducing excess into the codebase), please let me know.