### PR TITLE
Make the script POSIX compliant

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -136,9 +136,11 @@ download_fnm() {
     DOWNLOAD_DIR=$(mktempdir) || { echo "Unable to create a temporary directory under ${TMPDIR:-/tmp}."; exit 1; }
     trap "rm -rf '$DOWNLOAD_DIR'" EXIT INT HUP TERM
 
-    echo "Downloading $URL..."
+    echo "Installing fnm to $INSTALL_DIR"
 
     mkdir -p "$INSTALL_DIR" >/dev/null 2>&1
+
+    echo "Downloading $URL..."
 
     if ! curl --progress-bar --fail -L "$URL" -o "$DOWNLOAD_DIR/$FILENAME.zip"; then
       echo "Download failed.  Check that the release/filename are correct."


### PR DESCRIPTION
There are some cases where Bash is not available or a smaller shell is used to run scripts (e.g. Debian Almquist shell). These changes make the script POSIX compliant, allowing it run in those shells.

- Common bashisms were replaced by POSIX compliant alternatives.
- A fallback for `mktemp` was added.
- A message was added to inform the user where fnm is being installed.