### PR TITLE
fix: linux shell inference when spaces or trailing slash in command

### DIFF
--- a/.changeset/fine-frogs-tease.md
+++ b/.changeset/fine-frogs-tease.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+fix: correct shell inference when path has spaces or trailing slash

--- a/src/shell/infer/unix.rs
+++ b/src/shell/infer/unix.rs
@@ -8,6 +8,7 @@ use thiserror::Error;
 #[derive(Debug)]
 struct ProcessInfo {
     parent_pid: Option<u32>,
+    parent_pid_str: String,
     command: String,
 }
 
@@ -28,13 +29,24 @@ pub fn infer_shell() -> Option<Box<dyn Shell>> {
                 err
             })
             .ok()?;
-        let binary = process_info
-            .command
-            .trim_start_matches('-')
-            .split('/')
-            .next_back()?;
+
+        debug!(
+            "pid {current_pid} parent process {} : {}",
+            process_info.parent_pid_str, process_info.command
+        );
+
+        let mut parts = process_info.command.trim_start_matches('-').split('/');
+
+        let mut binary = "";
+        while let Some(b) = parts.next_back() {
+            if !b.is_empty() {
+                binary = b;
+                break;
+            }
+        }
 
         if let Some(shell) = super::shell_from_string(binary) {
+            debug!("Found supported shell: {:?}", shell);
             return Some(shell);
         }
 
@@ -69,18 +81,15 @@ fn get_process_info(pid: u32) -> Result<ProcessInfo, ProcessInfoError> {
         .next()
         .ok_or_else(|| Error::from(ErrorKind::NotFound))??;
 
-    let mut parts = line.split_whitespace();
-    let ppid = parts.next().ok_or_else(|| ProcessInfoError::Parse {
-        expectation: "Can't read the ppid from ps, should be the first item in the table",
+    let (ppid, command_raw) = line.trim().split_once(char::is_whitespace).ok_or_else(|| ProcessInfoError::Parse {
+        expectation: "Can't split the ppid and program from ps, should be first and second items in the table",
         got: line.to_string(),
     })?;
-    let command = parts.next().ok_or_else(|| ProcessInfoError::Parse {
-        expectation: "Can't read the command from ps, should be the second item in the table",
-        got: line.to_string(),
-    })?;
+    let command = command_raw.trim_start();
 
     Ok(ProcessInfo {
         parent_pid: ppid.parse().ok(),
+        parent_pid_str: ppid.into(),
         command: command.into(),
     })
 }

--- a/src/shell/infer/windows.rs
+++ b/src/shell/infer/windows.rs
@@ -14,9 +14,9 @@ pub fn infer_shell() -> Option<Box<dyn Shell>> {
     while let Some(pid) = current_pid {
         if let Some(process) = system.process(pid) {
             current_pid = process.parent();
-            debug!("pid {pid} parent process is {current_pid:?}");
-            let process_name = process
-                .exe()
+            let exe = process.exe();
+            debug!("pid {pid} parent process is {current_pid:?}: {exe:?}");
+            let process_name = exe
                 .and_then(|x| {
                     tap_none(x.file_stem(), || {
                         warn!("failed to get file stem from {:?}", x);
@@ -33,6 +33,7 @@ pub fn infer_shell() -> Option<Box<dyn Shell>> {
                 .map(|x| &x[..])
                 .and_then(super::shell_from_string)
             {
+                debug!("Found supported shell: {:?}", shell);
                 return Some(shell);
             }
         } else {


### PR DESCRIPTION
Fixes #1482 - inferences which fail when the path has a trailing slash or includes a space. Aligns the debug output for windows and unix.

Path with spaces
```
$ exec -a "/path with space/to/bash" bash

$ pid=$$; while [ -n "$pid" ]; do read pid prog <<< "$(ps -o ppid,comm -p $pid | awk 'NR == 2 {print}')"; echo $pid $prog; done
3634 /path with space/to/bash
1 /Users/xxxxx/Applications/IntelliJ IDEA Ultimate.app/Contents/MacOS/idea
0 /sbin/launchd

$ RUST_LOG=debug cargo run -- env
...
[2025-12-02T22:42:18Z DEBUG fnm::shell::infer::unix] pid 28180 parent process 23954 : target/debug/fnm
[2025-12-02T22:42:18Z DEBUG fnm::shell::infer] binary is not a supported shell: "fnm"
[2025-12-02T22:42:18Z DEBUG fnm::shell::infer::unix] pid 23954 parent process 3634 : /path with space/to/bash
[2025-12-02T22:42:18Z DEBUG fnm::shell::infer::unix] Found supported shell: Bash
export PATH="/Users/xxxxxx/.local/state/fnm_multishells/28180_1764715338497/bin":"$PATH"
```

Trailing slash on symlink
```
$ exec /opt/homebrew/bin/bash/

$ pid=$$; while [ -n "$pid" ]; do read pid prog <<< "$(ps -o ppid,comm -p $pid | awk 'NR == 2 {print}')"; echo $pid $prog; done
3634 /opt/homebrew/bin/bash/
1 /Users/xxxxxx/Applications/IntelliJ IDEA Ultimate.app/Contents/MacOS/idea
0 /sbin/launchd

$ RUST_LOG=debug cargo run -- env
...
[2025-12-02T22:50:32Z DEBUG fnm::shell::infer::unix] pid 31244 parent process 23954 : target/debug/fnm
[2025-12-02T22:50:32Z DEBUG fnm::shell::infer] binary is not a supported shell: "fnm"
[2025-12-02T22:50:32Z DEBUG fnm::shell::infer::unix] pid 23954 parent process 3634 : /opt/homebrew/bin/bash/
[2025-12-02T22:50:32Z DEBUG fnm::shell::infer::unix] Found supported shell: Bash
export PATH="/Users/xxxxxx/.local/state/fnm_multishells/31244_1764715832655/bin":"$PATH"
```