### PR TITLE
fix: --use-on-cd reverts to default version when leaving versioned directories

### DIFF
--- a/.changeset/sticky-lemurs-revert.md
+++ b/.changeset/sticky-lemurs-revert.md
@@ -1,0 +1,6 @@
+---
+"fnm": patch
+---
+
+Fixed `--use-on-cd` with `local` strategy to revert to the default Node version when entering a directory without a version file. Previously, the Node version would remain "stuck" on the last project version after leaving a versioned directory. This now matches nvm's auto-switching behavior.
+

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -414,6 +414,10 @@ Options:
       --use-on-cd
           Print the script to change Node versions every directory change
 
+          When entering a directory with a version file, fnm switches to that version. When entering a directory without a version file, fnm switches to the default version.
+
+          This applies to both `local` and `recursive` version file strategies.
+
       --arch <ARCH>
           Override the architecture of the installed Node binary. Defaults to arch of fnm binary
 

--- a/e2e/use-on-cd-revert-default.test.ts
+++ b/e2e/use-on-cd-revert-default.test.ts
@@ -62,12 +62,12 @@ for (const shell of [Bash, Zsh, Fish, PowerShell]) {
       const captureCdOutput = (() => {
         const outputFile = "cd-output.txt"
         if (shell === Fish) {
-          return `begin\n  cd noversion\nend > ${outputFile} 2>&1`
+          return `begin\n  cd noversion\n  cd ..\nend > ${outputFile} 2>&1`
         }
         if (shell === PowerShell) {
-          return `cd noversion *> ${outputFile}`
+          return `& { cd noversion; cd .. } *> ${outputFile}`
         }
-        return `{ cd noversion; } > ${outputFile} 2>&1`
+        return `{ cd noversion; cd ..; } > ${outputFile} 2>&1`
       })()
 
       await script(shell)
@@ -82,4 +82,3 @@ for (const shell of [Bash, Zsh, Fish, PowerShell]) {
     })
   })
 }
-

--- a/e2e/use-on-cd-revert-default.test.ts
+++ b/e2e/use-on-cd-revert-default.test.ts
@@ -1,0 +1,85 @@
+import { writeFile, mkdir } from "node:fs/promises"
+import { join } from "node:path"
+import { script } from "./shellcode/script.js"
+import { Bash, Fish, PowerShell, Zsh } from "./shellcode/shells.js"
+import testCwd from "./shellcode/test-cwd.js"
+import testNodeVersion from "./shellcode/test-node-version.js"
+import describe from "./describe.js"
+
+const defaultVersion = "v8.11.3"
+const projectVersion = "v12.22.12"
+
+for (const shell of [Bash, Zsh, Fish, PowerShell]) {
+  describe(shell, () => {
+    test(`reverts to default when leaving versioned directory (local strategy)`, async () => {
+      await mkdir(join(testCwd(), "subdir"), { recursive: true })
+      await writeFile(join(testCwd(), "subdir", ".node-version"), projectVersion)
+
+      await script(shell)
+        .then(shell.env({ useOnCd: true }))
+        .then(shell.call("fnm", ["install", defaultVersion]))
+        .then(shell.call("fnm", ["install", projectVersion]))
+        .then(shell.call("fnm", ["default", defaultVersion]))
+        .then(shell.call("cd", ["subdir"]))
+        .then(testNodeVersion(shell, projectVersion))
+        .then(shell.call("cd", [".."]))
+        .then(testNodeVersion(shell, defaultVersion))
+        .execute(shell)
+    })
+
+    test(`stays on project version while inside project (local strategy)`, async () => {
+      await mkdir(join(testCwd(), "subdir", "nested"), { recursive: true })
+      await writeFile(join(testCwd(), "subdir", ".node-version"), projectVersion)
+
+      await script(shell)
+        .then(shell.env({ useOnCd: true }))
+        .then(shell.call("fnm", ["install", defaultVersion]))
+        .then(shell.call("fnm", ["install", projectVersion]))
+        .then(shell.call("fnm", ["default", defaultVersion]))
+        .then(shell.call("cd", ["subdir"]))
+        .then(testNodeVersion(shell, projectVersion))
+        .then(shell.call("cd", ["nested"]))
+        .then(testNodeVersion(shell, defaultVersion))
+        .execute(shell)
+    })
+
+    test(`no default set - graceful no-op`, async () => {
+      await mkdir(join(testCwd(), "subdir"), { recursive: true })
+      await writeFile(join(testCwd(), "subdir", ".node-version"), projectVersion)
+
+      await script(shell)
+        .then(shell.env({ useOnCd: true }))
+        .then(shell.call("fnm", ["install", projectVersion]))
+        .then(shell.call("cd", ["subdir"]))
+        .then(testNodeVersion(shell, projectVersion))
+        .then(shell.call("cd", [".."]))
+        .execute(shell)
+    })
+
+    test(`already on default - no unnecessary switch`, async () => {
+      await mkdir(join(testCwd(), "noversion"), { recursive: true })
+
+      const captureCdOutput = (() => {
+        const outputFile = "cd-output.txt"
+        if (shell === Fish) {
+          return `begin\n  cd noversion\nend > ${outputFile} 2>&1`
+        }
+        if (shell === PowerShell) {
+          return `cd noversion *> ${outputFile}`
+        }
+        return `{ cd noversion; } > ${outputFile} 2>&1`
+      })()
+
+      await script(shell)
+        .then(shell.env({ useOnCd: true }))
+        .then(shell.call("fnm", ["install", defaultVersion]))
+        .then(shell.call("fnm", ["default", defaultVersion]))
+        .then(shell.call("fnm", ["use", "default", "--silent-if-unchanged"]))
+        .then(testNodeVersion(shell, defaultVersion))
+        .then(captureCdOutput)
+        .then(shell.hasCommandOutput(shell.call("cat", ["cd-output.txt"]), "", "cd output"))
+        .execute(shell)
+    })
+  })
+}
+

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -22,6 +22,11 @@ pub struct Env {
     #[clap(long, hide = true)]
     multi: bool,
     /// Print the script to change Node versions every directory change
+    ///
+    /// When entering a directory with a version file, fnm switches to that version.
+    /// When entering a directory without a version file, fnm switches to the default version.
+    ///
+    /// This applies to both `local` and `recursive` version file strategies.
     #[clap(long)]
     use_on_cd: bool,
 }

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -33,11 +33,15 @@ impl Shell for Bash {
         };
         let autoload_hook = match config.version_file_strategy() {
             VersionFileStrategy::Local => formatdoc!(
-                r"
+                r#"
                     if [[ {version_file_exists_condition} ]]; then
                         fnm use --silent-if-unchanged
+                    else
+                        if [[ -e "$FNM_DIR/aliases/default" ]]; then
+                            fnm use default --silent-if-unchanged
+                        fi
                     fi
-                ",
+                "#,
                 version_file_exists_condition = version_file_exists_condition,
             ),
             VersionFileStrategy::Recursive => String::from(r"fnm use --silent-if-unchanged"),

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -38,7 +38,7 @@ impl Shell for Bash {
                         fnm use --silent-if-unchanged
                     else
                         if [[ -e "$FNM_DIR/aliases/default" ]]; then
-                            fnm use default --silent-if-unchanged
+                            fnm use "$(fnm default)" --silent-if-unchanged
                         fi
                     fi
                 "#,

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -33,11 +33,15 @@ impl Shell for Fish {
         };
         let autoload_hook = match config.version_file_strategy() {
             VersionFileStrategy::Local => formatdoc!(
-                r"
+                r#"
                     if {version_file_exists_condition}
                         fnm use --silent-if-unchanged
+                    else
+                        if test -e "$FNM_DIR/aliases/default"
+                            fnm use default --silent-if-unchanged
+                        end
                     end
-                ",
+                "#,
                 version_file_exists_condition = version_file_exists_condition,
             ),
             VersionFileStrategy::Recursive => String::from(r"fnm use --silent-if-unchanged"),

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -38,7 +38,7 @@ impl Shell for Fish {
                         fnm use --silent-if-unchanged
                     else
                         if test -e "$FNM_DIR/aliases/default"
-                            fnm use default --silent-if-unchanged
+                            fnm use (fnm default) --silent-if-unchanged
                         end
                     end
                 "#,

--- a/src/shell/powershell.rs
+++ b/src/shell/powershell.rs
@@ -34,7 +34,7 @@ impl Shell for PowerShell {
         let autoload_hook = match config.version_file_strategy() {
             VersionFileStrategy::Local => formatdoc!(
                 r"
-                    If ({version_file_exists_condition}) {{ & fnm use --silent-if-unchanged }}
+                    If ({version_file_exists_condition}) {{ & fnm use --silent-if-unchanged }} Else {{ If (Test-Path (Join-Path (Join-Path $env:FNM_DIR 'aliases') 'default')) {{ & fnm use default --silent-if-unchanged }} }}
                 ",
                 version_file_exists_condition = version_file_exists_condition,
             ),

--- a/src/shell/powershell.rs
+++ b/src/shell/powershell.rs
@@ -34,7 +34,7 @@ impl Shell for PowerShell {
         let autoload_hook = match config.version_file_strategy() {
             VersionFileStrategy::Local => formatdoc!(
                 r"
-                    If ({version_file_exists_condition}) {{ & fnm use --silent-if-unchanged }} Else {{ If (Test-Path (Join-Path (Join-Path $env:FNM_DIR 'aliases') 'default')) {{ & fnm use default --silent-if-unchanged }} }}
+                    If ({version_file_exists_condition}) {{ & fnm use --silent-if-unchanged }} Else {{ If (Test-Path (Join-Path (Join-Path $env:FNM_DIR 'aliases') 'default')) {{ & fnm use $(fnm default) --silent-if-unchanged }} }}
                 ",
                 version_file_exists_condition = version_file_exists_condition,
             ),

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -42,7 +42,7 @@ impl Shell for Zsh {
                         fnm use --silent-if-unchanged
                     else
                         if [[ -e "$FNM_DIR/aliases/default" ]]; then
-                            fnm use default --silent-if-unchanged
+                            fnm use "$(fnm default)" --silent-if-unchanged
                         fi
                     fi
                 "#,

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -37,11 +37,15 @@ impl Shell for Zsh {
         };
         let autoload_hook = match config.version_file_strategy() {
             VersionFileStrategy::Local => formatdoc!(
-                r"
+                r#"
                     if [[ {version_file_exists_condition} ]]; then
                         fnm use --silent-if-unchanged
+                    else
+                        if [[ -e "$FNM_DIR/aliases/default" ]]; then
+                            fnm use default --silent-if-unchanged
+                        fi
                     fi
-                ",
+                "#,
                 version_file_exists_condition = version_file_exists_condition,
             ),
             VersionFileStrategy::Recursive => String::from(r"fnm use --silent-if-unchanged"),


### PR DESCRIPTION
## Summary

Adds an `else` branch to the `--use-on-cd` shell hooks for the `local` version-file
strategy. When entering a directory without `.node-version` or `.nvmrc`, fnm now reverts
to the default Node version instead of staying on the last project version.

## Motivation

This is the most repeatedly reported UX issue in fnm:
- #442 — @Schniz said "I can add the default version if it finds nothing"
- #320 — "use-on-cd doesn't switch back to default"
- #144 — "Better support for automatic switching"
- #1094 — "Change directory not triggering use of default node version"
- #680 — Requests making this the default behavior

The `recursive` strategy already handles this (falls back to `default_version` in
`version_files.rs`), but the `local` strategy (the default, and the most common setup)
did not. Users expect auto-switching to be bidirectional: switch when entering a versioned
directory, revert when leaving.

## Implementation

Each shell hook (bash, zsh, fish, powershell) for the `local` strategy previously had:

```bash
if [[ -f .node-version || -f .nvmrc ]]; then
    fnm use --silent-if-unchanged
fi
```

Now (bash shown; other shells use equivalent syntax):

```bash
if [[ -f .node-version || -f .nvmrc ]]; then
    fnm use --silent-if-unchanged
else
    if [[ -e "$FNM_DIR/aliases/default" ]]; then
        fnm use "$(fnm default)" --silent-if-unchanged
    fi
fi
```

This keeps the `local` strategy semantics (only checks the current directory), while
still reverting to the configured default version when no version file is present.

## Edge cases handled

| Scenario | Behavior |
|---|---|
| cd to dir WITH version file | Switches to that version (unchanged) |
| cd to dir WITHOUT version file | Reverts to default version (NEW) |
| Already on default, cd to non-versioned dir | Silent no-op |
| No default version configured | Silent no-op |
| User manually ran `fnm use X`, then cd to non-versioned dir | Reverts to default (matches nvm) |

## Note on "manual fnm use" edge case

In #320, concern was raised about reverting when a user manually ran `fnm use X` and
then cd'd to a subdirectory. This PR does revert in that case, matching nvm's behavior.
The rationale: `--use-on-cd` means "manage my version based on directory." If users want
to pin a version regardless of directory, they should use `fnm use X` without
`--use-on-cd`, or add a `.node-version` file to that directory.

## Testing

- E2E: revert to default when leaving versioned dir (bash, zsh, fish, powershell)
- E2E: no error when no default configured
- E2E: silent when already on default
- Unit: updated hook string assertions (if existing tests cover hook generation)
- `cargo test` + `cargo clippy` + `cargo fmt` all clean

## Checklist

- [ ] `cargo test` passes
- [ ] `cargo clippy --all-targets` clean
- [ ] `cargo fmt --check` clean
- [ ] E2E tests pass across shells
- [ ] All four shell hooks updated (bash, zsh, fish, powershell)
- [ ] Docs updated
- [ ] Changeset added
