### PR TITLE
feat(env): apply initial use during env --use-on-cd

### DIFF
--- a/.changeset/bright-buckets-yell.md
+++ b/.changeset/bright-buckets-yell.md
@@ -1,0 +1,5 @@
+---
+"fnm": minor
+---
+
+Reduce shell startup overhead for `env --use-on-cd` by applying the initial version during `fnm env`, instead of requiring an immediate extra `fnm use` subprocess from shell hook output.

--- a/e2e/use-on-cd.test.ts
+++ b/e2e/use-on-cd.test.ts
@@ -21,6 +21,18 @@ for (const shell of [Bash, Zsh, Fish, PowerShell, WinCmd]) {
         .execute(shell)
     })
 
+    test(`uses current directory version immediately on env setup`, async () => {
+      await writeFile(join(testCwd(), ".node-version"), "v12.22.12")
+      await script(shell)
+        .then(shell.env({}))
+        .then(shell.call("fnm", ["install", "v8.11.3"]))
+        .then(shell.call("fnm", ["install", "v12.22.12"]))
+        .then(shell.call("fnm", ["use", "v8.11.3"]))
+        .then(shell.env({ useOnCd: true }))
+        .then(testNodeVersion(shell, "v12.22.12"))
+        .execute(shell)
+    })
+
     test(`with resolve-engines`, async () => {
       await mkdir(join(testCwd(), "subdir"), { recursive: true })
       await writeFile(

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -1,4 +1,5 @@
 use super::command::Command;
+use super::r#use::Use;
 use crate::config::FnmConfig;
 use crate::fs::symlink_dir;
 use crate::outln;
@@ -8,6 +9,7 @@ use clap::ValueEnum;
 use colored::Colorize;
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::io::IsTerminal;
 use thiserror::Error;
 
 #[derive(clap::Parser, Debug, Default)]
@@ -54,6 +56,23 @@ fn bool_as_str(value: bool) -> &'static str {
         "true"
     } else {
         "false"
+    }
+}
+
+fn set_path_for_multishell(multishell_path: &std::path::Path) {
+    let path_for_node = if cfg!(windows) {
+        multishell_path.to_path_buf()
+    } else {
+        multishell_path.join("bin")
+    };
+
+    let current_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut split_paths: Vec<_> = std::env::split_paths(&current_path).collect();
+    split_paths.insert(0, path_for_node);
+    if let Ok(new_path) = std::env::join_paths(split_paths) {
+        unsafe {
+            std::env::set_var("PATH", new_path);
+        }
     }
 }
 
@@ -118,6 +137,29 @@ impl Command for Env {
         }
 
         if self.use_on_cd {
+            // Call `use` internally for the initial directory, so the shell doesn't
+            // need to spawn a subprocess after evaluating the env output.
+            set_path_for_multishell(&multishell_path);
+            let config_with_multishell =
+                config.clone().with_multishell_path(multishell_path.clone());
+            let use_cmd = Use {
+                version: None,
+                install_if_missing: false,
+                silent_if_unchanged: true,
+                info_to_stderr: true,
+            };
+            let should_force_stderr_color = !std::io::stdout().is_terminal()
+                && std::io::stderr().is_terminal()
+                && std::env::var_os("NO_COLOR").is_none();
+            if should_force_stderr_color {
+                colored::control::set_override(true);
+            }
+            // Ignore errors - if there's no version file, that's fine
+            let _ = use_cmd.apply(&config_with_multishell);
+            if should_force_stderr_color {
+                colored::control::unset_override();
+            }
+
             println!("{}", shell.use_on_cd(config)?);
         }
         if let Some(v) = shell.rehash() {

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -212,6 +212,7 @@ fn use_installed_version(version: &Version, config: &FnmConfig) -> Result<(), Er
         ))),
         install_if_missing: false,
         silent_if_unchanged: false,
+        info_to_stderr: false,
     }
     .apply(config)
     .map_err(|source| Error::UseError {

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -25,6 +25,10 @@ pub struct Use {
     /// if it will not change due to execution of this command
     #[clap(long)]
     pub silent_if_unchanged: bool,
+
+    /// Print informational output to stderr (used internally by `fnm env`)
+    #[clap(skip)]
+    pub info_to_stderr: bool,
 }
 
 impl Command for Use {
@@ -96,7 +100,11 @@ impl Command for Use {
         };
 
         if !self.silent_if_unchanged || will_version_change(&version_path, config) {
-            outln!(config, Info, "{}", message);
+            if self.info_to_stderr {
+                outln!(config, Error, "{}", message);
+            } else {
+                outln!(config, Info, "{}", message);
+            }
         }
 
         if let Some(multishells_path) = multishell_path.parent() {
@@ -144,6 +152,7 @@ fn install_new_version(
         version: Some(UserVersionReader::Direct(requested_version)),
         install_if_missing: true,
         silent_if_unchanged: false,
+        info_to_stderr: false,
     }
     .apply(config)?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use crate::path_ext::PathExt;
 use crate::version_file_strategy::VersionFileStrategy;
 use url::Url;
 
-#[derive(clap::Parser, Debug)]
+#[derive(clap::Parser, Debug, Clone)]
 pub struct FnmConfig {
     /// <https://nodejs.org/dist/> mirror
     #[clap(
@@ -171,6 +171,11 @@ impl FnmConfig {
     #[cfg(test)]
     pub fn with_base_dir(mut self, base_dir: Option<std::path::PathBuf>) -> Self {
         self.base_dir = base_dir;
+        self
+    }
+
+    pub fn with_multishell_path(mut self, multishell_path: std::path::PathBuf) -> Self {
+        self.multishell_path = Some(multishell_path);
         self
     }
 }

--- a/src/directories.rs
+++ b/src/directories.rs
@@ -27,7 +27,7 @@ fn cache_dir(basedirs: &impl BaseStrategy) -> PathBuf {
 
 /// A helper struct for directories in fnm that uses XDG Base Directory Specification
 /// if applicable for the platform.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Directories(
     #[cfg(windows)] etcetera::base_strategy::Windows,
     #[cfg(not(windows))] etcetera::base_strategy::Xdg,

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -54,7 +54,6 @@ impl Shell for Bash {
                 }}
 
                 alias cd=__fnmcd
-                __fnm_use_if_file_found
             "#,
             autoload_hook = autoload_hook
         ))

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -48,8 +48,6 @@ impl Shell for Fish {
                     status --is-command-substitution; and return
                     {autoload_hook}
                 end
-
-                _fnm_autoload_hook
             ",
             autoload_hook = autoload_hook
         ))

--- a/src/shell/powershell.rs
+++ b/src/shell/powershell.rs
@@ -46,7 +46,6 @@ impl Shell for PowerShell {
                 function global:Set-LocationWithFnm {{ param($path); if ($path -eq $null) {{Set-Location}} else {{Set-Location $path}}; Set-FnmOnLoad }}
                 Set-Alias -Scope global cd_with_fnm Set-LocationWithFnm
                 Set-Alias -Option AllScope -Scope global cd Set-LocationWithFnm
-                Set-FnmOnLoad
             ",
             autoload_hook = autoload_hook
         ))

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -53,8 +53,7 @@ impl Shell for Zsh {
                     {autoload_hook}
                 }}
 
-                add-zsh-hook chpwd _fnm_autoload_hook \
-                    && _fnm_autoload_hook
+                add-zsh-hook chpwd _fnm_autoload_hook
             ",
             autoload_hook = autoload_hook
         ))


### PR DESCRIPTION
## Why
`fnm env --use-on-cd` previously relied on shell hook output to immediately spawn an extra `fnm use` subprocess after eval. This change applies the initial version inside `fnm env` itself, reducing shell startup overhead and making initialization smoother.