### PR TITLE
Clarify interactive install prompt source

### DIFF
--- a/.changeset/fair-carrots-greet.md
+++ b/.changeset/fair-carrots-greet.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+Clarify the interactive `fnm use` missing-version prompt by prefixing the message with `fnm` so it is obvious which tool is asking to install Node.

--- a/src/commands/use.rs
+++ b/src/commands/use.rs
@@ -181,7 +181,7 @@ fn should_install_interactively(requested_version: &UserVersion) -> bool {
     }
 
     let error_message = format!(
-        "Can't find an installed Node version matching {}.",
+        "fnm can't find an installed Node version matching {}.",
         requested_version.to_string().italic()
     );
     eprintln!("{}", error_message.red());


### PR DESCRIPTION
## Summary
- prefix the missing-version interactive message with `fnm` so it's clear who is prompting
- keep the existing install confirmation flow unchanged while improving first-time readability

Closes #1521