### PR TITLE
Pin shell in installer-generated env setup

### DIFF
--- a/.changeset/cuddly-cars-ring.md
+++ b/.changeset/cuddly-cars-ring.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+prefer explicit shell flags in installer-generated shell setup and fix ARM installer CI platform selection

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -177,7 +177,7 @@ setup_shell() {
       if [ "$USE_HOMEBREW" != "true" ]; then
         echo '  export PATH="$FNM_PATH:$PATH"'
       fi
-      echo '  eval "`fnm env`"'
+      echo '  eval "$(fnm env --shell zsh)"'
       echo 'fi'
     } | tee -a "$CONF_FILE"
 
@@ -193,7 +193,7 @@ setup_shell() {
       if [ "$USE_HOMEBREW" != "true" ]; then
         echo '  set PATH "$FNM_PATH" $PATH'
       fi
-      echo '  fnm env | source'
+      echo '  fnm env --shell fish | source'
       echo 'end'
     } | tee -a "$CONF_FILE"
 
@@ -213,7 +213,7 @@ setup_shell() {
       if [ "$USE_HOMEBREW" != "true" ]; then
         echo '  export PATH="$FNM_PATH:$PATH"'
       fi
-      echo '  eval "`fnm env`"'
+      echo '  eval "$(fnm env --shell bash)"'
       echo 'fi'
     } | tee -a "$CONF_FILE"
 

--- a/.github/workflows/installation_script.yml
+++ b/.github/workflows/installation_script.yml
@@ -1,5 +1,5 @@
 name: Installation script
-on: 
+on:
   pull_request:
     paths:
       - .ci/install.sh
@@ -13,9 +13,11 @@ jobs:
   test_against_latest_release_arm:
     strategy:
       matrix:
-        docker_image:
-          - arm64v8/ubuntu
-          - arm32v7/ubuntu
+        include:
+          - docker_image: arm64v8/ubuntu
+            docker_platform: linux/arm64/v8
+          - docker_image: arm32v7/ubuntu
+            docker_platform: linux/arm/v7
     name: Test against latest release (ARM)
     runs-on: ubuntu-latest
     steps:
@@ -25,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run installation script in Docker
         run: |
-          docker run --rm -v $(pwd):$(pwd) -e "RUST_LOG=fnm=debug" --workdir $(pwd) ${{matrix.docker_image}} bash -c '
+          docker run --rm --platform ${{ matrix.docker_platform }} -v $(pwd):$(pwd) -e "RUST_LOG=fnm=debug" --workdir $(pwd) ${{matrix.docker_image}} bash -c '
             set -e
 
             apt update && apt install -y unzip curl libatomic1
@@ -53,13 +55,13 @@ jobs:
     strategy:
       matrix:
         shell: [fish, zsh, bash]
-        setup: 
+        setup:
           - os: ubuntu
-            script_arguments: ''
+            script_arguments: ""
           - os: macos
-            script_arguments: ''
+            script_arguments: ""
           - os: macos
-            script_arguments: '--force-no-brew'
+            script_arguments: "--force-no-brew"
     runs-on: ${{ matrix.setup.os }}-latest
     steps:
       - uses: actions/checkout@v4
@@ -84,4 +86,4 @@ jobs:
       - run: "env SHELL=$(which ${{ matrix.shell }}) bash ./.ci/install.sh ${{ matrix.setup.script_arguments }}"
         name: Run the installation script
       - run: ./.ci/test_installation_script.sh ${{ matrix.shell }}
-        name: 'Test installation script'
+        name: "Test installation script"

--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ Please follow your shell instructions to install them.
 Environment variables need to be setup before you can start using fnm.
 This is done by evaluating the output of `fnm env`.
 
+> [!TIP]
+> Prefer passing an explicit shell (for example `fnm env --shell bash`) instead of relying on shell inference at runtime. It is a bit faster and avoids process tree detection.
+
 > [!NOTE]
 > Check out the [Configuration](./docs/configuration.md) section to enable highly
 > recommended features, like automatic version switching.
@@ -197,7 +200,7 @@ fnm env --use-on-cd --shell powershell | Out-String | Invoke-Expression
 
 #### Windows Command Prompt aka Batch aka WinCMD
 
-fnm is also supported but is not entirely covered. You can set up a startup script for [cmd.exe]( https://superuser.com/a/144348) or [Windows Terminal](https://superuser.com/a/1855283) and append the following lines:
+fnm is also supported but is not entirely covered. You can set up a startup script for [cmd.exe](https://superuser.com/a/144348) or [Windows Terminal](https://superuser.com/a/1855283) and append the following lines:
 
 ```batch
 @echo off

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -380,7 +380,7 @@ Print and set up required environment variables for fnm
 
 This command generates a series of shell commands that should be evaluated by your shell to create a fnm-ready environment.
 
-Each shell has its own syntax of evaluating a dynamic expression. For example, evaluating fnm on Bash and Zsh would look like `eval "$(fnm env)"`. In Fish, evaluating would look like `fnm env | source`
+Each shell has its own syntax of evaluating a dynamic expression. For example, evaluating fnm on Bash and Zsh would look like `eval "$(fnm env --shell bash)"`. In Fish, evaluating would look like `fnm env --shell fish | source`
 
 Usage: fnm env [OPTIONS]
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,8 +27,8 @@ pub enum SubCommand {
     /// should be evaluated by your shell to create a fnm-ready environment.
     ///
     /// Each shell has its own syntax of evaluating a dynamic expression.
-    /// For example, evaluating fnm on Bash and Zsh would look like `eval "$(fnm env)"`.
-    /// In Fish, evaluating would look like `fnm env | source`
+    /// For example, evaluating fnm on Bash and Zsh would look like `eval "$(fnm env --shell bash)"`.
+    /// In Fish, evaluating would look like `fnm env --shell fish | source`
     #[clap(name = "env", bin_name = "env")]
     Env(commands::env::Env),
 


### PR DESCRIPTION
## Summary
- Update `.ci/install.sh` to write explicit shell flags in generated shell init snippets (`--shell bash|zsh|fish`) instead of relying on runtime shell inference.
- Keep runtime shell inference in `fnm env`/`fnm completions` unchanged for backwards compatibility, while nudging users toward explicit shell usage.
- Update user-facing docs (`README.md` and generated `docs/commands.md`) so examples prefer explicit shell selection and mention the small performance benefit.

Closes #365