### PR TITLE
Add generated man pages for fnm and subcommands

### DIFF
--- a/.changeset/serious-shoes-sleep.md
+++ b/.changeset/serious-shoes-sleep.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+Add generated man pages for `fnm` and subcommands, and keep them in sync through CI and release prep checks.

--- a/.ci/prepare-version.js
+++ b/.ci/prepare-version.js
@@ -18,6 +18,7 @@ const command = cmd.command({
     updateCargoToml(await getPackageVersion())
     exec("cargo build --release")
     exec("pnpm generate-command-docs --binary-path=./target/release/fnm")
+    exec("pnpm generate-man-page --binary-path=./target/release/fnm")
     exec("./.ci/record_screen.sh")
   },
 })
@@ -34,7 +35,7 @@ cmd.run(cmd.binary(command), process.argv)
 async function getPackageVersion() {
   const pkgJson = await fs.promises.readFile(
     new URL("../package.json", import.meta.url),
-    "utf8"
+    "utf8",
   )
   const version = JSON.parse(pkgJson).version
   assert(version, "package.json version is not set")
@@ -48,7 +49,7 @@ function updateCargoToml(nextVersion) {
 
   const newToml = cargoToml.replace(
     `version = "${currentVersion}"`,
-    `version = "${nextVersion}"`
+    `version = "${nextVersion}"`,
   )
 
   if (newToml === cargoToml) {

--- a/.ci/print-man-page.js
+++ b/.ci/print-man-page.js
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+
+/// @ts-check
+
+import { execa } from "execa"
+import fs from "node:fs"
+import cmd from "cmd-ts"
+import cmdFs from "cmd-ts/dist/cjs/batteries/fs.js"
+
+const FnmBinaryPath = {
+  ...cmdFs.ExistingPath,
+  defaultValue() {
+    const target = new URL("../target/debug/fnm", import.meta.url)
+    if (!fs.existsSync(target)) {
+      throw new Error(
+        "Can't find debug target, please run `cargo build` or provide a specific binary path",
+      )
+    }
+    return target.pathname
+  },
+}
+
+const command = cmd.command({
+  name: "print-man-page",
+  description: "prints the man/*.1 files with updated contents",
+  args: {
+    checkForDirty: cmd.flag({
+      long: "check",
+      description: `Check that file was not changed`,
+    }),
+    fnmPath: cmd.option({
+      long: "binary-path",
+      description: "the fnm binary path",
+      type: FnmBinaryPath,
+    }),
+  },
+  async handler({ checkForDirty, fnmPath }) {
+    const targetFiles = await main(fnmPath)
+    if (checkForDirty) {
+      const gitStatus = await checkGitStatus(targetFiles)
+      if (gitStatus.state === "dirty") {
+        process.exitCode = 1
+        console.error(
+          "The files have changed. Please re-run `pnpm generate-man-page`.",
+        )
+        console.error(`hint: The following diff was found:`)
+        console.error()
+        console.error(gitStatus.diff)
+      }
+    }
+  },
+})
+
+cmd.run(cmd.binary(command), process.argv).catch((err) => {
+  console.error(err)
+  process.exitCode = process.exitCode || 1
+})
+
+/**
+ * @param {string} fnmPath
+ * @returns {Promise<string[]>}
+ */
+async function main(fnmPath) {
+  const manDir = new URL("../man/", import.meta.url).pathname
+  await fs.promises.mkdir(manDir, { recursive: true })
+  const subcommands = await getSubcommands(fnmPath)
+  const targets = [
+    {
+      path: `${manDir}fnm.1`,
+      args: ["man"],
+    },
+    ...subcommands.map((name) => ({
+      path: `${manDir}fnm-${name}.1`,
+      args: ["man", name],
+    })),
+  ]
+
+  for (const target of targets) {
+    await writeManPage(fnmPath, target.path, target.args)
+  }
+
+  return targets.map((target) => target.path)
+}
+
+/**
+ * @param {string} fnmPath
+ * @param {string} targetFile
+ * @param {string[]} args
+ * @returns {Promise<void>}
+ */
+async function writeManPage(fnmPath, targetFile, args) {
+  const result = await execa(fnmPath, args, {
+    reject: false,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr || "Failed generating man page")
+  }
+
+  await fs.promises.writeFile(targetFile, result.stdout, "utf8")
+}
+
+/**
+ * @param {string} fnmPath
+ * @returns {Promise<string[]>}
+ */
+async function getSubcommands(fnmPath) {
+  const result = await execa(fnmPath, ["--help"], {
+    reject: false,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr || "Failed reading fnm --help")
+  }
+
+  const rows = result.stdout.split("\n")
+  const commandsHeader = rows.findIndex((line) => line.trim() === "Commands:")
+
+  if (commandsHeader === -1) {
+    return []
+  }
+
+  const end = rows.indexOf("", commandsHeader + 1)
+  const commandRows = rows.slice(
+    commandsHeader + 1,
+    end === -1 ? undefined : end,
+  )
+
+  /** @type {string[]} */
+  const subcommands = []
+
+  for (const row of commandRows) {
+    const [name] = row.trim().split(/\s+/)
+    if (!name) {
+      continue
+    }
+    subcommands.push(name)
+  }
+
+  return subcommands
+}
+
+/**
+ * @param {string[]} targetFiles
+ * @returns {Promise<{ state: "dirty", diff: string } | { state: "clean" }>}
+ */
+async function checkGitStatus(targetFiles) {
+  if (targetFiles.length === 0) {
+    return { state: "clean" }
+  }
+
+  const { stdout, exitCode } = await execa(
+    `git`,
+    ["diff", "--color", "--exit-code", ...targetFiles],
+    {
+      reject: false,
+    },
+  )
+  if (exitCode === 0) {
+    return { state: "clean" }
+  }
+  return { state: "dirty", diff: stdout }
+}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -374,6 +374,7 @@ jobs:
       - name: Generate command markdown
         run: |
           pnpm run generate-command-docs --check --binary-path=$(which fnm)
+          pnpm run generate-man-page --check --binary-path=$(which fnm)
 
       # TODO: use bnz
       # run_e2e_benchmarks:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
+name = "clap_mangen"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ea63a92086df93893164221ad4f24142086d535b3a0957b9b9bea2dc86301"
+dependencies = [
+ "clap",
+ "roff",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,6 +684,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "clap_mangen",
  "colored",
  "csv",
  "duct",
@@ -1434,7 +1445,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1609,6 +1620,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "roff"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ url = "2.5.0"
 sysinfo = "0.30.12"
 thiserror = "1.0.61"
 clap_complete = "4.5.2"
+clap_mangen = "0.2.24"
 anyhow = "1.0.86"
 indicatif = { version = "0.17.8", features = ["improved_unicode"] }
 flate2 = "1.0.30"

--- a/README.md
+++ b/README.md
@@ -131,6 +131,27 @@ Where `<SHELL>` can be one of the supported shells:
 
 Please follow your shell instructions to install them.
 
+## Man page
+
+`fnm` ships generated man pages under `man/*.1` (`fnm.1` and command-specific pages such as `fnm-install.1`).
+
+You can open it directly from the repository:
+
+```sh
+man ./man/fnm.1
+```
+
+Or install all pages under your manpath, for example:
+
+```sh
+mkdir -p "$HOME/.local/share/man/man1"
+cp ./man/*.1 "$HOME/.local/share/man/man1/"
+man fnm
+man fnm-install
+```
+
+If you install fnm via a package manager (for example Homebrew), the man page may already be installed for you.
+
 ### Shell Setup
 
 Environment variables need to be setup before you can start using fnm.

--- a/man/fnm-alias.1
+++ b/man/fnm-alias.1
@@ -1,0 +1,84 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH fnm-alias 1  "alias " 
+.SH NAME
+fnm\-alias \- Alias a version to a common name
+.SH SYNOPSIS
+\fBalias\fR [\fB\-\-node\-dist\-mirror\fR] [\fB\-\-fnm\-dir\fR] [\fB\-\-log\-level\fR] [\fB\-\-arch\fR] [\fB\-\-version\-file\-strategy\fR] [\fB\-\-corepack\-enabled\fR] [\fB\-\-resolve\-engines\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fITO_VERSION\fR> <\fINAME\fR> 
+.SH DESCRIPTION
+Alias a version to a common name
+.SH OPTIONS
+.TP
+\fB\-\-node\-dist\-mirror\fR \fI<NODE_DIST_MIRROR>\fR [default: https://nodejs.org/dist]
+<https://nodejs.org/dist/> mirror
+.RS
+May also be specified with the \fBFNM_NODE_DIST_MIRROR\fR environment variable. 
+.RE
+.TP
+\fB\-\-fnm\-dir\fR \fI<BASE_DIR>\fR
+The root directory of fnm installations
+.RS
+May also be specified with the \fBFNM_DIR\fR environment variable. 
+.RE
+.TP
+\fB\-\-log\-level\fR \fI<LOG_LEVEL>\fR [default: info]
+The log level of fnm commands
+.br
+
+.br
+[\fIpossible values: \fRquiet, error, info]
+.RS
+May also be specified with the \fBFNM_LOGLEVEL\fR environment variable. 
+.RE
+.TP
+\fB\-\-arch\fR \fI<ARCH>\fR
+Override the architecture of the installed Node binary. Defaults to arch of fnm binary
+.RS
+May also be specified with the \fBFNM_ARCH\fR environment variable. 
+.RE
+.TP
+\fB\-\-version\-file\-strategy\fR \fI<VERSION_FILE_STRATEGY>\fR [default: local]
+A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a version, or when `\-\-use\-on\-cd` is configured on evaluation
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+local: Use the local version of Node defined within the current directory
+.IP \(bu 2
+recursive: Use the version of Node defined within the current directory and all parent directories
+.RE
+.RS
+May also be specified with the \fBFNM_VERSION_FILE_STRATEGY\fR environment variable. 
+.RE
+.TP
+\fB\-\-corepack\-enabled\fR
+Enable corepack support for each new installation. This will make fnm call `corepack enable` on every Node.js installation. For more information about corepack see <https://nodejs.org/api/corepack.html>
+.RS
+May also be specified with the \fBFNM_COREPACK_ENABLED\fR environment variable. 
+.RE
+.TP
+\fB\-\-resolve\-engines\fR [\fI<RESOLVE_ENGINES>\fR]
+Resolve `engines.node` field in `package.json` whenever a `.node\-version` or `.nvmrc` file is not present.
+This feature is enabled by default. To disable it, provide `\-\-resolve\-engines=false`.
+
+Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+        In the future, disabling it might be a no\-op, so it\*(Aqs worth knowing any reason to
+        do that.
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
+.RS
+May also be specified with the \fBFNM_RESOLVE_ENGINES\fR environment variable. 
+.RE
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)
+.TP
+<\fITO_VERSION\fR>
+
+.TP
+<\fINAME\fR>

--- a/man/fnm-completions.1
+++ b/man/fnm-completions.1
@@ -1,0 +1,86 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH fnm-completions 1  "completions " 
+.SH NAME
+fnm\-completions \- Print shell completions to stdout
+.SH SYNOPSIS
+\fBcompletions\fR [\fB\-\-node\-dist\-mirror\fR] [\fB\-\-shell\fR] [\fB\-\-fnm\-dir\fR] [\fB\-\-log\-level\fR] [\fB\-\-arch\fR] [\fB\-\-version\-file\-strategy\fR] [\fB\-\-corepack\-enabled\fR] [\fB\-\-resolve\-engines\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+Print shell completions to stdout
+.SH OPTIONS
+.TP
+\fB\-\-node\-dist\-mirror\fR \fI<NODE_DIST_MIRROR>\fR [default: https://nodejs.org/dist]
+<https://nodejs.org/dist/> mirror
+.RS
+May also be specified with the \fBFNM_NODE_DIST_MIRROR\fR environment variable. 
+.RE
+.TP
+\fB\-\-shell\fR \fI<SHELL>\fR
+The shell syntax to use. Infers when missing
+.br
+
+.br
+[\fIpossible values: \fRbash, zsh, fish, powershell]
+.TP
+\fB\-\-fnm\-dir\fR \fI<BASE_DIR>\fR
+The root directory of fnm installations
+.RS
+May also be specified with the \fBFNM_DIR\fR environment variable. 
+.RE
+.TP
+\fB\-\-log\-level\fR \fI<LOG_LEVEL>\fR [default: info]
+The log level of fnm commands
+.br
+
+.br
+[\fIpossible values: \fRquiet, error, info]
+.RS
+May also be specified with the \fBFNM_LOGLEVEL\fR environment variable. 
+.RE
+.TP
+\fB\-\-arch\fR \fI<ARCH>\fR
+Override the architecture of the installed Node binary. Defaults to arch of fnm binary
+.RS
+May also be specified with the \fBFNM_ARCH\fR environment variable. 
+.RE
+.TP
+\fB\-\-version\-file\-strategy\fR \fI<VERSION_FILE_STRATEGY>\fR [default: local]
+A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a version, or when `\-\-use\-on\-cd` is configured on evaluation
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+local: Use the local version of Node defined within the current directory
+.IP \(bu 2
+recursive: Use the version of Node defined within the current directory and all parent directories
+.RE
+.RS
+May also be specified with the \fBFNM_VERSION_FILE_STRATEGY\fR environment variable. 
+.RE
+.TP
+\fB\-\-corepack\-enabled\fR
+Enable corepack support for each new installation. This will make fnm call `corepack enable` on every Node.js installation. For more information about corepack see <https://nodejs.org/api/corepack.html>
+.RS
+May also be specified with the \fBFNM_COREPACK_ENABLED\fR environment variable. 
+.RE
+.TP
+\fB\-\-resolve\-engines\fR [\fI<RESOLVE_ENGINES>\fR]
+Resolve `engines.node` field in `package.json` whenever a `.node\-version` or `.nvmrc` file is not present.
+This feature is enabled by default. To disable it, provide `\-\-resolve\-engines=false`.
+
+Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+        In the future, disabling it might be a no\-op, so it\*(Aqs worth knowing any reason to
+        do that.
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
+.RS
+May also be specified with the \fBFNM_RESOLVE_ENGINES\fR environment variable. 
+.RE
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/fnm-current.1
+++ b/man/fnm-current.1
@@ -1,0 +1,79 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH fnm-current 1  "current " 
+.SH NAME
+fnm\-current \- Print the current Node.js version
+.SH SYNOPSIS
+\fBcurrent\fR [\fB\-\-node\-dist\-mirror\fR] [\fB\-\-fnm\-dir\fR] [\fB\-\-log\-level\fR] [\fB\-\-arch\fR] [\fB\-\-version\-file\-strategy\fR] [\fB\-\-corepack\-enabled\fR] [\fB\-\-resolve\-engines\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+Print the current Node.js version
+.SH OPTIONS
+.TP
+\fB\-\-node\-dist\-mirror\fR \fI<NODE_DIST_MIRROR>\fR [default: https://nodejs.org/dist]
+<https://nodejs.org/dist/> mirror
+.RS
+May also be specified with the \fBFNM_NODE_DIST_MIRROR\fR environment variable. 
+.RE
+.TP
+\fB\-\-fnm\-dir\fR \fI<BASE_DIR>\fR
+The root directory of fnm installations
+.RS
+May also be specified with the \fBFNM_DIR\fR environment variable. 
+.RE
+.TP
+\fB\-\-log\-level\fR \fI<LOG_LEVEL>\fR [default: info]
+The log level of fnm commands
+.br
+
+.br
+[\fIpossible values: \fRquiet, error, info]
+.RS
+May also be specified with the \fBFNM_LOGLEVEL\fR environment variable. 
+.RE
+.TP
+\fB\-\-arch\fR \fI<ARCH>\fR
+Override the architecture of the installed Node binary. Defaults to arch of fnm binary
+.RS
+May also be specified with the \fBFNM_ARCH\fR environment variable. 
+.RE
+.TP
+\fB\-\-version\-file\-strategy\fR \fI<VERSION_FILE_STRATEGY>\fR [default: local]
+A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a version, or when `\-\-use\-on\-cd` is configured on evaluation
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+local: Use the local version of Node defined within the current directory
+.IP \(bu 2
+recursive: Use the version of Node defined within the current directory and all parent directories
+.RE
+.RS
+May also be specified with the \fBFNM_VERSION_FILE_STRATEGY\fR environment variable. 
+.RE
+.TP
+\fB\-\-corepack\-enabled\fR
+Enable corepack support for each new installation. This will make fnm call `corepack enable` on every Node.js installation. For more information about corepack see <https://nodejs.org/api/corepack.html>
+.RS
+May also be specified with the \fBFNM_COREPACK_ENABLED\fR environment variable. 
+.RE
+.TP
+\fB\-\-resolve\-engines\fR [\fI<RESOLVE_ENGINES>\fR]
+Resolve `engines.node` field in `package.json` whenever a `.node\-version` or `.nvmrc` file is not present.
+This feature is enabled by default. To disable it, provide `\-\-resolve\-engines=false`.
+
+Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+        In the future, disabling it might be a no\-op, so it\*(Aqs worth knowing any reason to
+        do that.
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
+.RS
+May also be specified with the \fBFNM_RESOLVE_ENGINES\fR environment variable. 
+.RE
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/fnm-default.1
+++ b/man/fnm-default.1
@@ -1,0 +1,83 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH fnm-default 1  "default " 
+.SH NAME
+fnm\-default \- Set a version as the default version or get the current default version
+.SH SYNOPSIS
+\fBdefault\fR [\fB\-\-node\-dist\-mirror\fR] [\fB\-\-fnm\-dir\fR] [\fB\-\-log\-level\fR] [\fB\-\-arch\fR] [\fB\-\-version\-file\-strategy\fR] [\fB\-\-corepack\-enabled\fR] [\fB\-\-resolve\-engines\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIVERSION\fR] 
+.SH DESCRIPTION
+Set a version as the default version or get the current default version.
+.PP
+This is a shorthand for `fnm alias VERSION default`
+.SH OPTIONS
+.TP
+\fB\-\-node\-dist\-mirror\fR \fI<NODE_DIST_MIRROR>\fR [default: https://nodejs.org/dist]
+<https://nodejs.org/dist/> mirror
+.RS
+May also be specified with the \fBFNM_NODE_DIST_MIRROR\fR environment variable. 
+.RE
+.TP
+\fB\-\-fnm\-dir\fR \fI<BASE_DIR>\fR
+The root directory of fnm installations
+.RS
+May also be specified with the \fBFNM_DIR\fR environment variable. 
+.RE
+.TP
+\fB\-\-log\-level\fR \fI<LOG_LEVEL>\fR [default: info]
+The log level of fnm commands
+.br
+
+.br
+[\fIpossible values: \fRquiet, error, info]
+.RS
+May also be specified with the \fBFNM_LOGLEVEL\fR environment variable. 
+.RE
+.TP
+\fB\-\-arch\fR \fI<ARCH>\fR
+Override the architecture of the installed Node binary. Defaults to arch of fnm binary
+.RS
+May also be specified with the \fBFNM_ARCH\fR environment variable. 
+.RE
+.TP
+\fB\-\-version\-file\-strategy\fR \fI<VERSION_FILE_STRATEGY>\fR [default: local]
+A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a version, or when `\-\-use\-on\-cd` is configured on evaluation
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+local: Use the local version of Node defined within the current directory
+.IP \(bu 2
+recursive: Use the version of Node defined within the current directory and all parent directories
+.RE
+.RS
+May also be specified with the \fBFNM_VERSION_FILE_STRATEGY\fR environment variable. 
+.RE
+.TP
+\fB\-\-corepack\-enabled\fR
+Enable corepack support for each new installation. This will make fnm call `corepack enable` on every Node.js installation. For more information about corepack see <https://nodejs.org/api/corepack.html>
+.RS
+May also be specified with the \fBFNM_COREPACK_ENABLED\fR environment variable. 
+.RE
+.TP
+\fB\-\-resolve\-engines\fR [\fI<RESOLVE_ENGINES>\fR]
+Resolve `engines.node` field in `package.json` whenever a `.node\-version` or `.nvmrc` file is not present.
+This feature is enabled by default. To disable it, provide `\-\-resolve\-engines=false`.
+
+Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+        In the future, disabling it might be a no\-op, so it\*(Aqs worth knowing any reason to
+        do that.
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
+.RS
+May also be specified with the \fBFNM_RESOLVE_ENGINES\fR environment variable. 
+.RE
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)
+.TP
+[\fIVERSION\fR]

--- a/man/fnm-env.1
+++ b/man/fnm-env.1
@@ -1,0 +1,96 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH fnm-env 1  "env " 
+.SH NAME
+fnm\-env \- Print and set up required environment variables for fnm
+.SH SYNOPSIS
+\fBenv\fR [\fB\-\-node\-dist\-mirror\fR] [\fB\-\-shell\fR] [\fB\-\-fnm\-dir\fR] [\fB\-\-json\fR] [\fB\-\-log\-level\fR] [\fB\-\-use\-on\-cd\fR] [\fB\-\-arch\fR] [\fB\-\-version\-file\-strategy\fR] [\fB\-\-corepack\-enabled\fR] [\fB\-\-resolve\-engines\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+Print and set up required environment variables for fnm
+.PP
+This command generates a series of shell commands that should be evaluated by your shell to create a fnm\-ready environment.
+.PP
+Each shell has its own syntax of evaluating a dynamic expression. For example, evaluating fnm on Bash and Zsh would look like `eval "$(fnm env \-\-shell bash)"`. In Fish, evaluating would look like `fnm env \-\-shell fish | source`
+.SH OPTIONS
+.TP
+\fB\-\-node\-dist\-mirror\fR \fI<NODE_DIST_MIRROR>\fR [default: https://nodejs.org/dist]
+<https://nodejs.org/dist/> mirror
+.RS
+May also be specified with the \fBFNM_NODE_DIST_MIRROR\fR environment variable. 
+.RE
+.TP
+\fB\-\-shell\fR \fI<SHELL>\fR
+The shell syntax to use. Infers when missing
+.br
+
+.br
+[\fIpossible values: \fRbash, zsh, fish, powershell]
+.TP
+\fB\-\-fnm\-dir\fR \fI<BASE_DIR>\fR
+The root directory of fnm installations
+.RS
+May also be specified with the \fBFNM_DIR\fR environment variable. 
+.RE
+.TP
+\fB\-\-json\fR
+Print JSON instead of shell commands
+.TP
+\fB\-\-log\-level\fR \fI<LOG_LEVEL>\fR [default: info]
+The log level of fnm commands
+.br
+
+.br
+[\fIpossible values: \fRquiet, error, info]
+.RS
+May also be specified with the \fBFNM_LOGLEVEL\fR environment variable. 
+.RE
+.TP
+\fB\-\-use\-on\-cd\fR
+Print the script to change Node versions every directory change
+.TP
+\fB\-\-arch\fR \fI<ARCH>\fR
+Override the architecture of the installed Node binary. Defaults to arch of fnm binary
+.RS
+May also be specified with the \fBFNM_ARCH\fR environment variable. 
+.RE
+.TP
+\fB\-\-version\-file\-strategy\fR \fI<VERSION_FILE_STRATEGY>\fR [default: local]
+A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a version, or when `\-\-use\-on\-cd` is configured on evaluation
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+local: Use the local version of Node defined within the current directory
+.IP \(bu 2
+recursive: Use the version of Node defined within the current directory and all parent directories
+.RE
+.RS
+May also be specified with the \fBFNM_VERSION_FILE_STRATEGY\fR environment variable. 
+.RE
+.TP
+\fB\-\-corepack\-enabled\fR
+Enable corepack support for each new installation. This will make fnm call `corepack enable` on every Node.js installation. For more information about corepack see <https://nodejs.org/api/corepack.html>
+.RS
+May also be specified with the \fBFNM_COREPACK_ENABLED\fR environment variable. 
+.RE
+.TP
+\fB\-\-resolve\-engines\fR [\fI<RESOLVE_ENGINES>\fR]
+Resolve `engines.node` field in `package.json` whenever a `.node\-version` or `.nvmrc` file is not present.
+This feature is enabled by default. To disable it, provide `\-\-resolve\-engines=false`.
+
+Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+        In the future, disabling it might be a no\-op, so it\*(Aqs worth knowing any reason to
+        do that.
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
+.RS
+May also be specified with the \fBFNM_RESOLVE_ENGINES\fR environment variable. 
+.RE
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/fnm-exec.1
+++ b/man/fnm-exec.1
@@ -1,0 +1,90 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH fnm-exec 1  "exec " 
+.SH NAME
+fnm\-exec \- Run a command within fnm context
+.SH SYNOPSIS
+\fBexec\fR [\fB\-\-node\-dist\-mirror\fR] [\fB\-\-using\fR] [\fB\-\-fnm\-dir\fR] [\fB\-\-log\-level\fR] [\fB\-\-arch\fR] [\fB\-\-version\-file\-strategy\fR] [\fB\-\-corepack\-enabled\fR] [\fB\-\-resolve\-engines\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIARGUMENTS\fR] 
+.SH DESCRIPTION
+Run a command within fnm context
+.PP
+Example:
+\-\-\-\-\-\-\-\-
+fnm exec \-\-using=v12.0.0 node \-\-version
+=> v12.0.0
+.SH OPTIONS
+.TP
+\fB\-\-node\-dist\-mirror\fR \fI<NODE_DIST_MIRROR>\fR [default: https://nodejs.org/dist]
+<https://nodejs.org/dist/> mirror
+.RS
+May also be specified with the \fBFNM_NODE_DIST_MIRROR\fR environment variable. 
+.RE
+.TP
+\fB\-\-using\fR \fI<VERSION>\fR
+Either an explicit version, or a filename with the version written in it
+.TP
+\fB\-\-fnm\-dir\fR \fI<BASE_DIR>\fR
+The root directory of fnm installations
+.RS
+May also be specified with the \fBFNM_DIR\fR environment variable. 
+.RE
+.TP
+\fB\-\-log\-level\fR \fI<LOG_LEVEL>\fR [default: info]
+The log level of fnm commands
+.br
+
+.br
+[\fIpossible values: \fRquiet, error, info]
+.RS
+May also be specified with the \fBFNM_LOGLEVEL\fR environment variable. 
+.RE
+.TP
+\fB\-\-arch\fR \fI<ARCH>\fR
+Override the architecture of the installed Node binary. Defaults to arch of fnm binary
+.RS
+May also be specified with the \fBFNM_ARCH\fR environment variable. 
+.RE
+.TP
+\fB\-\-version\-file\-strategy\fR \fI<VERSION_FILE_STRATEGY>\fR [default: local]
+A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a version, or when `\-\-use\-on\-cd` is configured on evaluation
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+local: Use the local version of Node defined within the current directory
+.IP \(bu 2
+recursive: Use the version of Node defined within the current directory and all parent directories
+.RE
+.RS
+May also be specified with the \fBFNM_VERSION_FILE_STRATEGY\fR environment variable. 
+.RE
+.TP
+\fB\-\-corepack\-enabled\fR
+Enable corepack support for each new installation. This will make fnm call `corepack enable` on every Node.js installation. For more information about corepack see <https://nodejs.org/api/corepack.html>
+.RS
+May also be specified with the \fBFNM_COREPACK_ENABLED\fR environment variable. 
+.RE
+.TP
+\fB\-\-resolve\-engines\fR [\fI<RESOLVE_ENGINES>\fR]
+Resolve `engines.node` field in `package.json` whenever a `.node\-version` or `.nvmrc` file is not present.
+This feature is enabled by default. To disable it, provide `\-\-resolve\-engines=false`.
+
+Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+        In the future, disabling it might be a no\-op, so it\*(Aqs worth knowing any reason to
+        do that.
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
+.RS
+May also be specified with the \fBFNM_RESOLVE_ENGINES\fR environment variable. 
+.RE
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)
+.TP
+[\fIARGUMENTS\fR]
+The command to run

--- a/man/fnm-help.1
+++ b/man/fnm-help.1
@@ -1,0 +1,49 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH fnm-help 1  "help " 
+.SH NAME
+fnm\-help \- Print this message or the help of the given subcommand(s)
+.SH SYNOPSIS
+\fBfnm help\fR [\fIsubcommands\fR]
+.SH DESCRIPTION
+Print this message or the help of the given subcommand(s)
+.SH SUBCOMMANDS
+.TP
+fnm\-help\-list\-remote(1)
+List all remote Node.js versions
+.TP
+fnm\-help\-list(1)
+List all locally installed Node.js versions
+.TP
+fnm\-help\-install(1)
+Install a new Node.js version
+.TP
+fnm\-help\-use(1)
+Change Node.js version
+.TP
+fnm\-help\-env(1)
+Print and set up required environment variables for fnm
+.TP
+fnm\-help\-completions(1)
+Print shell completions to stdout
+.TP
+fnm\-help\-alias(1)
+Alias a version to a common name
+.TP
+fnm\-help\-unalias(1)
+Remove an alias definition
+.TP
+fnm\-help\-default(1)
+Set a version as the default version or get the current default version
+.TP
+fnm\-help\-current(1)
+Print the current Node.js version
+.TP
+fnm\-help\-exec(1)
+Run a command within fnm context
+.TP
+fnm\-help\-uninstall(1)
+Uninstall a Node.js version
+.TP
+fnm\-help\-help(1)
+Print this message or the help of the given subcommand(s)

--- a/man/fnm-install.1
+++ b/man/fnm-install.1
@@ -1,0 +1,98 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH fnm-install 1  "install " 
+.SH NAME
+fnm\-install \- Install a new Node.js version
+.SH SYNOPSIS
+\fBinstall\fR [\fB\-\-lts\fR] [\fB\-\-node\-dist\-mirror\fR] [\fB\-\-fnm\-dir\fR] [\fB\-\-latest\fR] [\fB\-\-progress\fR] [\fB\-\-log\-level\fR] [\fB\-\-use\fR] [\fB\-\-arch\fR] [\fB\-\-version\-file\-strategy\fR] [\fB\-\-corepack\-enabled\fR] [\fB\-\-resolve\-engines\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIVERSION\fR] 
+.SH DESCRIPTION
+Install a new Node.js version
+.SH OPTIONS
+.TP
+\fB\-\-lts\fR
+Install latest LTS
+.TP
+\fB\-\-node\-dist\-mirror\fR \fI<NODE_DIST_MIRROR>\fR [default: https://nodejs.org/dist]
+<https://nodejs.org/dist/> mirror
+.RS
+May also be specified with the \fBFNM_NODE_DIST_MIRROR\fR environment variable. 
+.RE
+.TP
+\fB\-\-fnm\-dir\fR \fI<BASE_DIR>\fR
+The root directory of fnm installations
+.RS
+May also be specified with the \fBFNM_DIR\fR environment variable. 
+.RE
+.TP
+\fB\-\-latest\fR
+Install latest version
+.TP
+\fB\-\-progress\fR \fI<PROGRESS>\fR [default: auto]
+Show an interactive progress bar for the download status
+.br
+
+.br
+[\fIpossible values: \fRauto, never, always]
+.TP
+\fB\-\-log\-level\fR \fI<LOG_LEVEL>\fR [default: info]
+The log level of fnm commands
+.br
+
+.br
+[\fIpossible values: \fRquiet, error, info]
+.RS
+May also be specified with the \fBFNM_LOGLEVEL\fR environment variable. 
+.RE
+.TP
+\fB\-\-use\fR
+Use the installed version immediately after installation
+.TP
+\fB\-\-arch\fR \fI<ARCH>\fR
+Override the architecture of the installed Node binary. Defaults to arch of fnm binary
+.RS
+May also be specified with the \fBFNM_ARCH\fR environment variable. 
+.RE
+.TP
+\fB\-\-version\-file\-strategy\fR \fI<VERSION_FILE_STRATEGY>\fR [default: local]
+A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a version, or when `\-\-use\-on\-cd` is configured on evaluation
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+local: Use the local version of Node defined within the current directory
+.IP \(bu 2
+recursive: Use the version of Node defined within the current directory and all parent directories
+.RE
+.RS
+May also be specified with the \fBFNM_VERSION_FILE_STRATEGY\fR environment variable. 
+.RE
+.TP
+\fB\-\-corepack\-enabled\fR
+Enable corepack support for each new installation. This will make fnm call `corepack enable` on every Node.js installation. For more information about corepack see <https://nodejs.org/api/corepack.html>
+.RS
+May also be specified with the \fBFNM_COREPACK_ENABLED\fR environment variable. 
+.RE
+.TP
+\fB\-\-resolve\-engines\fR [\fI<RESOLVE_ENGINES>\fR]
+Resolve `engines.node` field in `package.json` whenever a `.node\-version` or `.nvmrc` file is not present.
+This feature is enabled by default. To disable it, provide `\-\-resolve\-engines=false`.
+
+Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+        In the future, disabling it might be a no\-op, so it\*(Aqs worth knowing any reason to
+        do that.
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
+.RS
+May also be specified with the \fBFNM_RESOLVE_ENGINES\fR environment variable. 
+.RE
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)
+.TP
+[\fIVERSION\fR]
+A version string. Can be a partial semver or a LTS version name by the format lts/NAME

--- a/man/fnm-list-remote.1
+++ b/man/fnm-list-remote.1
@@ -1,0 +1,101 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH fnm-list-remote 1  "list-remote " 
+.SH NAME
+fnm\-list\-remote \- List all remote Node.js versions
+.SH SYNOPSIS
+\fBlist\-remote\fR [\fB\-\-filter\fR] [\fB\-\-node\-dist\-mirror\fR] [\fB\-\-fnm\-dir\fR] [\fB\-\-lts\fR] [\fB\-\-sort\fR] [\fB\-\-latest\fR] [\fB\-\-log\-level\fR] [\fB\-\-arch\fR] [\fB\-\-version\-file\-strategy\fR] [\fB\-\-corepack\-enabled\fR] [\fB\-\-resolve\-engines\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+List all remote Node.js versions
+.SH OPTIONS
+.TP
+\fB\-\-filter\fR \fI<FILTER>\fR
+Filter versions by a user\-defined version or a semver range
+.TP
+\fB\-\-node\-dist\-mirror\fR \fI<NODE_DIST_MIRROR>\fR [default: https://nodejs.org/dist]
+<https://nodejs.org/dist/> mirror
+.RS
+May also be specified with the \fBFNM_NODE_DIST_MIRROR\fR environment variable. 
+.RE
+.TP
+\fB\-\-fnm\-dir\fR \fI<BASE_DIR>\fR
+The root directory of fnm installations
+.RS
+May also be specified with the \fBFNM_DIR\fR environment variable. 
+.RE
+.TP
+\fB\-\-lts\fR [\fI<LTS>\fR]
+Show only LTS versions (optionally filter by LTS codename)
+.TP
+\fB\-\-sort\fR \fI<SORT>\fR [default: asc]
+Version sorting order
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+desc: Sort versions in descending order (latest to earliest)
+.IP \(bu 2
+asc: Sort versions in ascending order (earliest to latest)
+.RE
+.TP
+\fB\-\-latest\fR
+Only show the latest matching version
+.TP
+\fB\-\-log\-level\fR \fI<LOG_LEVEL>\fR [default: info]
+The log level of fnm commands
+.br
+
+.br
+[\fIpossible values: \fRquiet, error, info]
+.RS
+May also be specified with the \fBFNM_LOGLEVEL\fR environment variable. 
+.RE
+.TP
+\fB\-\-arch\fR \fI<ARCH>\fR
+Override the architecture of the installed Node binary. Defaults to arch of fnm binary
+.RS
+May also be specified with the \fBFNM_ARCH\fR environment variable. 
+.RE
+.TP
+\fB\-\-version\-file\-strategy\fR \fI<VERSION_FILE_STRATEGY>\fR [default: local]
+A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a version, or when `\-\-use\-on\-cd` is configured on evaluation
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+local: Use the local version of Node defined within the current directory
+.IP \(bu 2
+recursive: Use the version of Node defined within the current directory and all parent directories
+.RE
+.RS
+May also be specified with the \fBFNM_VERSION_FILE_STRATEGY\fR environment variable. 
+.RE
+.TP
+\fB\-\-corepack\-enabled\fR
+Enable corepack support for each new installation. This will make fnm call `corepack enable` on every Node.js installation. For more information about corepack see <https://nodejs.org/api/corepack.html>
+.RS
+May also be specified with the \fBFNM_COREPACK_ENABLED\fR environment variable. 
+.RE
+.TP
+\fB\-\-resolve\-engines\fR [\fI<RESOLVE_ENGINES>\fR]
+Resolve `engines.node` field in `package.json` whenever a `.node\-version` or `.nvmrc` file is not present.
+This feature is enabled by default. To disable it, provide `\-\-resolve\-engines=false`.
+
+Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+        In the future, disabling it might be a no\-op, so it\*(Aqs worth knowing any reason to
+        do that.
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
+.RS
+May also be specified with the \fBFNM_RESOLVE_ENGINES\fR environment variable. 
+.RE
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/fnm-list.1
+++ b/man/fnm-list.1
@@ -1,0 +1,79 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH fnm-list 1  "list " 
+.SH NAME
+fnm\-list \- List all locally installed Node.js versions
+.SH SYNOPSIS
+\fBlist\fR [\fB\-\-node\-dist\-mirror\fR] [\fB\-\-fnm\-dir\fR] [\fB\-\-log\-level\fR] [\fB\-\-arch\fR] [\fB\-\-version\-file\-strategy\fR] [\fB\-\-corepack\-enabled\fR] [\fB\-\-resolve\-engines\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+List all locally installed Node.js versions
+.SH OPTIONS
+.TP
+\fB\-\-node\-dist\-mirror\fR \fI<NODE_DIST_MIRROR>\fR [default: https://nodejs.org/dist]
+<https://nodejs.org/dist/> mirror
+.RS
+May also be specified with the \fBFNM_NODE_DIST_MIRROR\fR environment variable. 
+.RE
+.TP
+\fB\-\-fnm\-dir\fR \fI<BASE_DIR>\fR
+The root directory of fnm installations
+.RS
+May also be specified with the \fBFNM_DIR\fR environment variable. 
+.RE
+.TP
+\fB\-\-log\-level\fR \fI<LOG_LEVEL>\fR [default: info]
+The log level of fnm commands
+.br
+
+.br
+[\fIpossible values: \fRquiet, error, info]
+.RS
+May also be specified with the \fBFNM_LOGLEVEL\fR environment variable. 
+.RE
+.TP
+\fB\-\-arch\fR \fI<ARCH>\fR
+Override the architecture of the installed Node binary. Defaults to arch of fnm binary
+.RS
+May also be specified with the \fBFNM_ARCH\fR environment variable. 
+.RE
+.TP
+\fB\-\-version\-file\-strategy\fR \fI<VERSION_FILE_STRATEGY>\fR [default: local]
+A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a version, or when `\-\-use\-on\-cd` is configured on evaluation
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+local: Use the local version of Node defined within the current directory
+.IP \(bu 2
+recursive: Use the version of Node defined within the current directory and all parent directories
+.RE
+.RS
+May also be specified with the \fBFNM_VERSION_FILE_STRATEGY\fR environment variable. 
+.RE
+.TP
+\fB\-\-corepack\-enabled\fR
+Enable corepack support for each new installation. This will make fnm call `corepack enable` on every Node.js installation. For more information about corepack see <https://nodejs.org/api/corepack.html>
+.RS
+May also be specified with the \fBFNM_COREPACK_ENABLED\fR environment variable. 
+.RE
+.TP
+\fB\-\-resolve\-engines\fR [\fI<RESOLVE_ENGINES>\fR]
+Resolve `engines.node` field in `package.json` whenever a `.node\-version` or `.nvmrc` file is not present.
+This feature is enabled by default. To disable it, provide `\-\-resolve\-engines=false`.
+
+Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+        In the future, disabling it might be a no\-op, so it\*(Aqs worth knowing any reason to
+        do that.
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
+.RS
+May also be specified with the \fBFNM_RESOLVE_ENGINES\fR environment variable. 
+.RE
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/fnm-unalias.1
+++ b/man/fnm-unalias.1
@@ -1,0 +1,81 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH fnm-unalias 1  "unalias " 
+.SH NAME
+fnm\-unalias \- Remove an alias definition
+.SH SYNOPSIS
+\fBunalias\fR [\fB\-\-node\-dist\-mirror\fR] [\fB\-\-fnm\-dir\fR] [\fB\-\-log\-level\fR] [\fB\-\-arch\fR] [\fB\-\-version\-file\-strategy\fR] [\fB\-\-corepack\-enabled\fR] [\fB\-\-resolve\-engines\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fIREQUESTED_ALIAS\fR> 
+.SH DESCRIPTION
+Remove an alias definition
+.SH OPTIONS
+.TP
+\fB\-\-node\-dist\-mirror\fR \fI<NODE_DIST_MIRROR>\fR [default: https://nodejs.org/dist]
+<https://nodejs.org/dist/> mirror
+.RS
+May also be specified with the \fBFNM_NODE_DIST_MIRROR\fR environment variable. 
+.RE
+.TP
+\fB\-\-fnm\-dir\fR \fI<BASE_DIR>\fR
+The root directory of fnm installations
+.RS
+May also be specified with the \fBFNM_DIR\fR environment variable. 
+.RE
+.TP
+\fB\-\-log\-level\fR \fI<LOG_LEVEL>\fR [default: info]
+The log level of fnm commands
+.br
+
+.br
+[\fIpossible values: \fRquiet, error, info]
+.RS
+May also be specified with the \fBFNM_LOGLEVEL\fR environment variable. 
+.RE
+.TP
+\fB\-\-arch\fR \fI<ARCH>\fR
+Override the architecture of the installed Node binary. Defaults to arch of fnm binary
+.RS
+May also be specified with the \fBFNM_ARCH\fR environment variable. 
+.RE
+.TP
+\fB\-\-version\-file\-strategy\fR \fI<VERSION_FILE_STRATEGY>\fR [default: local]
+A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a version, or when `\-\-use\-on\-cd` is configured on evaluation
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+local: Use the local version of Node defined within the current directory
+.IP \(bu 2
+recursive: Use the version of Node defined within the current directory and all parent directories
+.RE
+.RS
+May also be specified with the \fBFNM_VERSION_FILE_STRATEGY\fR environment variable. 
+.RE
+.TP
+\fB\-\-corepack\-enabled\fR
+Enable corepack support for each new installation. This will make fnm call `corepack enable` on every Node.js installation. For more information about corepack see <https://nodejs.org/api/corepack.html>
+.RS
+May also be specified with the \fBFNM_COREPACK_ENABLED\fR environment variable. 
+.RE
+.TP
+\fB\-\-resolve\-engines\fR [\fI<RESOLVE_ENGINES>\fR]
+Resolve `engines.node` field in `package.json` whenever a `.node\-version` or `.nvmrc` file is not present.
+This feature is enabled by default. To disable it, provide `\-\-resolve\-engines=false`.
+
+Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+        In the future, disabling it might be a no\-op, so it\*(Aqs worth knowing any reason to
+        do that.
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
+.RS
+May also be specified with the \fBFNM_RESOLVE_ENGINES\fR environment variable. 
+.RE
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)
+.TP
+<\fIREQUESTED_ALIAS\fR>

--- a/man/fnm-uninstall.1
+++ b/man/fnm-uninstall.1
@@ -1,0 +1,83 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH fnm-uninstall 1  "uninstall " 
+.SH NAME
+fnm\-uninstall \- Uninstall a Node.js version
+.SH SYNOPSIS
+\fBuninstall\fR [\fB\-\-node\-dist\-mirror\fR] [\fB\-\-fnm\-dir\fR] [\fB\-\-log\-level\fR] [\fB\-\-arch\fR] [\fB\-\-version\-file\-strategy\fR] [\fB\-\-corepack\-enabled\fR] [\fB\-\-resolve\-engines\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIVERSION\fR] 
+.SH DESCRIPTION
+Uninstall a Node.js version
+.PP
+> Warning: when providing an alias, it will remove the Node version the alias > is pointing to, along with the other aliases that point to the same version.
+.SH OPTIONS
+.TP
+\fB\-\-node\-dist\-mirror\fR \fI<NODE_DIST_MIRROR>\fR [default: https://nodejs.org/dist]
+<https://nodejs.org/dist/> mirror
+.RS
+May also be specified with the \fBFNM_NODE_DIST_MIRROR\fR environment variable. 
+.RE
+.TP
+\fB\-\-fnm\-dir\fR \fI<BASE_DIR>\fR
+The root directory of fnm installations
+.RS
+May also be specified with the \fBFNM_DIR\fR environment variable. 
+.RE
+.TP
+\fB\-\-log\-level\fR \fI<LOG_LEVEL>\fR [default: info]
+The log level of fnm commands
+.br
+
+.br
+[\fIpossible values: \fRquiet, error, info]
+.RS
+May also be specified with the \fBFNM_LOGLEVEL\fR environment variable. 
+.RE
+.TP
+\fB\-\-arch\fR \fI<ARCH>\fR
+Override the architecture of the installed Node binary. Defaults to arch of fnm binary
+.RS
+May also be specified with the \fBFNM_ARCH\fR environment variable. 
+.RE
+.TP
+\fB\-\-version\-file\-strategy\fR \fI<VERSION_FILE_STRATEGY>\fR [default: local]
+A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a version, or when `\-\-use\-on\-cd` is configured on evaluation
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+local: Use the local version of Node defined within the current directory
+.IP \(bu 2
+recursive: Use the version of Node defined within the current directory and all parent directories
+.RE
+.RS
+May also be specified with the \fBFNM_VERSION_FILE_STRATEGY\fR environment variable. 
+.RE
+.TP
+\fB\-\-corepack\-enabled\fR
+Enable corepack support for each new installation. This will make fnm call `corepack enable` on every Node.js installation. For more information about corepack see <https://nodejs.org/api/corepack.html>
+.RS
+May also be specified with the \fBFNM_COREPACK_ENABLED\fR environment variable. 
+.RE
+.TP
+\fB\-\-resolve\-engines\fR [\fI<RESOLVE_ENGINES>\fR]
+Resolve `engines.node` field in `package.json` whenever a `.node\-version` or `.nvmrc` file is not present.
+This feature is enabled by default. To disable it, provide `\-\-resolve\-engines=false`.
+
+Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+        In the future, disabling it might be a no\-op, so it\*(Aqs worth knowing any reason to
+        do that.
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
+.RS
+May also be specified with the \fBFNM_RESOLVE_ENGINES\fR environment variable. 
+.RE
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)
+.TP
+[\fIVERSION\fR]

--- a/man/fnm-use.1
+++ b/man/fnm-use.1
@@ -1,0 +1,87 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH fnm-use 1  "use " 
+.SH NAME
+fnm\-use \- Change Node.js version
+.SH SYNOPSIS
+\fBuse\fR [\fB\-\-install\-if\-missing\fR] [\fB\-\-node\-dist\-mirror\fR] [\fB\-\-fnm\-dir\fR] [\fB\-\-silent\-if\-unchanged\fR] [\fB\-\-log\-level\fR] [\fB\-\-arch\fR] [\fB\-\-version\-file\-strategy\fR] [\fB\-\-corepack\-enabled\fR] [\fB\-\-resolve\-engines\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIVERSION\fR] 
+.SH DESCRIPTION
+Change Node.js version
+.SH OPTIONS
+.TP
+\fB\-\-install\-if\-missing\fR
+Install the version if it isn\*(Aqt installed yet
+.TP
+\fB\-\-node\-dist\-mirror\fR \fI<NODE_DIST_MIRROR>\fR [default: https://nodejs.org/dist]
+<https://nodejs.org/dist/> mirror
+.RS
+May also be specified with the \fBFNM_NODE_DIST_MIRROR\fR environment variable. 
+.RE
+.TP
+\fB\-\-fnm\-dir\fR \fI<BASE_DIR>\fR
+The root directory of fnm installations
+.RS
+May also be specified with the \fBFNM_DIR\fR environment variable. 
+.RE
+.TP
+\fB\-\-silent\-if\-unchanged\fR
+Don\*(Aqt output a message identifying the version being used if it will not change due to execution of this command
+.TP
+\fB\-\-log\-level\fR \fI<LOG_LEVEL>\fR [default: info]
+The log level of fnm commands
+.br
+
+.br
+[\fIpossible values: \fRquiet, error, info]
+.RS
+May also be specified with the \fBFNM_LOGLEVEL\fR environment variable. 
+.RE
+.TP
+\fB\-\-arch\fR \fI<ARCH>\fR
+Override the architecture of the installed Node binary. Defaults to arch of fnm binary
+.RS
+May also be specified with the \fBFNM_ARCH\fR environment variable. 
+.RE
+.TP
+\fB\-\-version\-file\-strategy\fR \fI<VERSION_FILE_STRATEGY>\fR [default: local]
+A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a version, or when `\-\-use\-on\-cd` is configured on evaluation
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+local: Use the local version of Node defined within the current directory
+.IP \(bu 2
+recursive: Use the version of Node defined within the current directory and all parent directories
+.RE
+.RS
+May also be specified with the \fBFNM_VERSION_FILE_STRATEGY\fR environment variable. 
+.RE
+.TP
+\fB\-\-corepack\-enabled\fR
+Enable corepack support for each new installation. This will make fnm call `corepack enable` on every Node.js installation. For more information about corepack see <https://nodejs.org/api/corepack.html>
+.RS
+May also be specified with the \fBFNM_COREPACK_ENABLED\fR environment variable. 
+.RE
+.TP
+\fB\-\-resolve\-engines\fR [\fI<RESOLVE_ENGINES>\fR]
+Resolve `engines.node` field in `package.json` whenever a `.node\-version` or `.nvmrc` file is not present.
+This feature is enabled by default. To disable it, provide `\-\-resolve\-engines=false`.
+
+Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+        In the future, disabling it might be a no\-op, so it\*(Aqs worth knowing any reason to
+        do that.
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
+.RS
+May also be specified with the \fBFNM_RESOLVE_ENGINES\fR environment variable. 
+.RE
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)
+.TP
+[\fIVERSION\fR]

--- a/man/fnm.1
+++ b/man/fnm.1
@@ -1,0 +1,124 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH fnm 1  "fnm 1.39.0" 
+.SH NAME
+fnm \- A fast and simple Node.js manager
+.SH SYNOPSIS
+\fBfnm\fR [\fB\-\-node\-dist\-mirror\fR] [\fB\-\-fnm\-dir\fR] [\fB\-\-log\-level\fR] [\fB\-\-arch\fR] [\fB\-\-version\-file\-strategy\fR] [\fB\-\-corepack\-enabled\fR] [\fB\-\-resolve\-engines\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIsubcommands\fR>
+.SH DESCRIPTION
+A fast and simple Node.js manager
+.SH OPTIONS
+.TP
+\fB\-\-node\-dist\-mirror\fR \fI<NODE_DIST_MIRROR>\fR [default: https://nodejs.org/dist]
+<https://nodejs.org/dist/> mirror
+.RS
+May also be specified with the \fBFNM_NODE_DIST_MIRROR\fR environment variable. 
+.RE
+.TP
+\fB\-\-fnm\-dir\fR \fI<BASE_DIR>\fR
+The root directory of fnm installations
+.RS
+May also be specified with the \fBFNM_DIR\fR environment variable. 
+.RE
+.TP
+\fB\-\-log\-level\fR \fI<LOG_LEVEL>\fR [default: info]
+The log level of fnm commands
+.br
+
+.br
+[\fIpossible values: \fRquiet, error, info]
+.RS
+May also be specified with the \fBFNM_LOGLEVEL\fR environment variable. 
+.RE
+.TP
+\fB\-\-arch\fR \fI<ARCH>\fR
+Override the architecture of the installed Node binary. Defaults to arch of fnm binary
+.RS
+May also be specified with the \fBFNM_ARCH\fR environment variable. 
+.RE
+.TP
+\fB\-\-version\-file\-strategy\fR \fI<VERSION_FILE_STRATEGY>\fR [default: local]
+A strategy for how to resolve the Node version. Used whenever `fnm use` or `fnm install` is called without a version, or when `\-\-use\-on\-cd` is configured on evaluation
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+local: Use the local version of Node defined within the current directory
+.IP \(bu 2
+recursive: Use the version of Node defined within the current directory and all parent directories
+.RE
+.RS
+May also be specified with the \fBFNM_VERSION_FILE_STRATEGY\fR environment variable. 
+.RE
+.TP
+\fB\-\-corepack\-enabled\fR
+Enable corepack support for each new installation. This will make fnm call `corepack enable` on every Node.js installation. For more information about corepack see <https://nodejs.org/api/corepack.html>
+.RS
+May also be specified with the \fBFNM_COREPACK_ENABLED\fR environment variable. 
+.RE
+.TP
+\fB\-\-resolve\-engines\fR [\fI<RESOLVE_ENGINES>\fR]
+Resolve `engines.node` field in `package.json` whenever a `.node\-version` or `.nvmrc` file is not present.
+This feature is enabled by default. To disable it, provide `\-\-resolve\-engines=false`.
+
+Note: `engines.node` can be any semver range, with the latest satisfying version being resolved.
+Note 2: If you disable it, please open an issue on GitHub describing _why_ you disabled it.
+        In the future, disabling it might be a no\-op, so it\*(Aqs worth knowing any reason to
+        do that.
+.br
+
+.br
+[\fIpossible values: \fRtrue, false]
+.RS
+May also be specified with the \fBFNM_RESOLVE_ENGINES\fR environment variable. 
+.RE
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version
+.SH SUBCOMMANDS
+.TP
+fnm\-list\-remote(1)
+List all remote Node.js versions
+.TP
+fnm\-list(1)
+List all locally installed Node.js versions
+.TP
+fnm\-install(1)
+Install a new Node.js version
+.TP
+fnm\-use(1)
+Change Node.js version
+.TP
+fnm\-env(1)
+Print and set up required environment variables for fnm
+.TP
+fnm\-completions(1)
+Print shell completions to stdout
+.TP
+fnm\-alias(1)
+Alias a version to a common name
+.TP
+fnm\-unalias(1)
+Remove an alias definition
+.TP
+fnm\-default(1)
+Set a version as the default version or get the current default version
+.TP
+fnm\-current(1)
+Print the current Node.js version
+.TP
+fnm\-exec(1)
+Run a command within fnm context
+.TP
+fnm\-uninstall(1)
+Uninstall a Node.js version
+.TP
+fnm\-help(1)
+Print this message or the help of the given subcommand(s)
+.SH VERSION
+v1.39.0

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "test": "cross-env NODE_OPTIONS='--experimental-vm-modules' jest",
     "version:prepare": "changeset version && ./.ci/prepare-version.js",
-    "generate-command-docs": "./.ci/print-command-docs.js"
+    "generate-command-docs": "./.ci/print-command-docs.js",
+    "generate-man-page": "./.ci/print-man-page.js"
   },
   "changelog": {
     "repo": "Schniz/fnm",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,6 +69,10 @@ pub enum SubCommand {
     /// > is pointing to, along with the other aliases that point to the same version.
     #[clap(name = "uninstall", bin_name = "uninstall", visible_aliases = &["uni"])]
     Uninstall(commands::uninstall::Uninstall),
+
+    /// Print man page to stdout
+    #[clap(name = "man", bin_name = "man", hide = true)]
+    Man(commands::man::ManPage),
 }
 
 impl SubCommand {
@@ -86,6 +90,7 @@ impl SubCommand {
             Self::Exec(cmd) => cmd.call(config),
             Self::Uninstall(cmd) => cmd.call(config),
             Self::Unalias(cmd) => cmd.call(config),
+            Self::Man(cmd) => cmd.call(config),
         }
     }
 }

--- a/src/commands/man.rs
+++ b/src/commands/man.rs
@@ -1,0 +1,47 @@
+use super::command::Command;
+use crate::cli::Cli;
+use crate::config::FnmConfig;
+use clap::CommandFactory;
+use clap::Parser;
+use clap_mangen::Man;
+use thiserror::Error;
+
+#[derive(Parser, Debug)]
+pub struct ManPage {
+    /// Command path to render (for example: install)
+    command: Vec<String>,
+}
+
+impl Command for ManPage {
+    type Error = Error;
+
+    fn apply(self, _config: &FnmConfig) -> Result<(), Self::Error> {
+        let mut app = Cli::command();
+        app.build();
+        let app = select_command(app, &self.command)?;
+        let mut output = std::io::stdout();
+        Man::new(app).render(&mut output)?;
+        Ok(())
+    }
+}
+
+fn select_command(mut app: clap::Command, path: &[String]) -> Result<clap::Command, Error> {
+    for name in path {
+        let command = app
+            .get_subcommands()
+            .find(|subcommand| subcommand.get_name() == name)
+            .cloned()
+            .ok_or_else(|| Error::UnknownSubcommand(name.to_owned()))?;
+        app = command;
+    }
+
+    Ok(app)
+}
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Unknown subcommand: {0}")]
+    UnknownSubcommand(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod exec;
 pub mod install;
 pub mod ls_local;
 pub mod ls_remote;
+pub mod man;
 pub mod unalias;
 pub mod uninstall;
 pub mod r#use;


### PR DESCRIPTION
## Summary
- add clap_mangen-backed manpage generation via a hidden `fnm man [subcommand...]` command
- generate and commit `man/*.1` files for `fnm` and each subcommand, and document usage/install in README
- wire generation into release prep and CI checks so manpages stay in sync with CLI changes
- add a patch changeset for shipping the new manpage workflow

## Testing
- cargo fmt
- cargo test
- pnpm run generate-command-docs --check --binary-path=./target/debug/fnm
- pnpm run generate-man-page --check --binary-path=./target/debug/fnm

Closes #1426