### PR TITLE
docs: add AGENTS guidance for e2e and changesets

### DIFF
--- a/.changeset/EXAMPLE.md
+++ b/.changeset/EXAMPLE.md
@@ -1,0 +1,12 @@
+---
+"fnm": patch
+---
+
+the title of the change in a few words.
+
+If necessary, you can add examples, links to related issues, or any other information that would be helpful for the maintainers and users of the project:
+
+```sh-session
+$ fnm whatever --hello world
+the output
+```

--- a/.changeset/green-clouds-argue.md
+++ b/.changeset/green-clouds-argue.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+Document contributor guidance for e2e tests and changesets in `AGENTS.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,46 +4,30 @@
 
 ### What they do
 
-E2E tests validate fnm behavior inside real shells, including shell integration, PATH updates, and cross-version workflows.
-They are used for user-facing behavior that unit tests cannot fully cover (for example: `fnm env`, `fnm use`, global package visibility, and shell-specific behavior).
+E2E tests validate user-facing fnm behavior inside real shells (`fnm env`, `fnm use`, PATH updates, global binaries, cross-version workflows).
 
 ### How they work
 
-- E2E tests live under `e2e/*.test.ts` and repro cases can live under `e2e/repros/*.test.ts`.
-- Tests are usually run in a shell matrix (commonly `Bash`, `Zsh`, `Fish`, `PowerShell`, `WinCmd`) via `describe(shell, () => { ... })`.
-- `script(shell)` builds a shell script step-by-step and executes it in an isolated temp directory.
-- `shell.env({...})` injects fnm shell setup and feature flags.
-- `shell.call("cmd", ["arg1", "arg2"])` appends command lines to the script.
-- `shell.scriptOutputContains(...)` and `shell.hasCommandOutput(...)` are the main assertion helpers.
-- The harness sets `FNM_NODE_DIST_MIRROR=http://localhost:8080` (proxy-backed), so tests should rely on existing mirrored behavior and avoid introducing unrelated network dependencies.
+- Tests live in `e2e/*.test.ts`; issue repros in `e2e/repros/*.test.ts`.
+- Most tests run a shell matrix via `describe(shell, () => { ... })`.
+- `script(shell)` builds and runs a shell script in isolated temp dirs.
+- Use `shell.env({...})`, `shell.call(...)`, `shell.scriptOutputContains(...)`, and `shell.hasCommandOutput(...)`.
+- Harness uses `FNM_NODE_DIST_MIRROR=http://localhost:8080`; avoid unrelated network dependencies.
 
 ### Where to look
 
-- Interface entrypoints:
-  - `e2e/shellcode/script.ts` (`script(shell)`, execution model, env wiring)
-  - `e2e/shellcode/shells.ts` (shell matrix definitions and capabilities)
-  - `e2e/shellcode/shells/types.ts` (shared shell/script interfaces)
-- Assertion helpers:
-  - `e2e/shellcode/shells/output-contains.ts` (`shell.scriptOutputContains`)
-  - `e2e/shellcode/shells/expect-command-output.ts` (`shell.hasCommandOutput`)
-  - `e2e/shellcode/shells/cmdCall.ts` (`shell.call` command construction)
-- Shell coverage behavior:
-  - `e2e/describe.ts` (shell-specific `describe`, WinCmd skip behavior)
-- Concrete test examples:
-  - `e2e/basic.test.ts` (core install/use/version assertions)
-  - `e2e/use-on-cd.test.ts` (directory-driven switching)
-  - `e2e/exec.test.ts` (`fnm exec` scenarios)
-  - `e2e/repros/issue-1527.test.ts` (issue repro pattern)
+- Core interfaces: `e2e/shellcode/script.ts`, `e2e/shellcode/shells.ts`, `e2e/shellcode/shells/types.ts`.
+- Assertions/helpers: `e2e/shellcode/shells/output-contains.ts`, `e2e/shellcode/shells/expect-command-output.ts`, `e2e/shellcode/shells/cmdCall.ts`.
+- Shell coverage behavior: `e2e/describe.ts`.
+- Example tests: `e2e/basic.test.ts`, `e2e/use-on-cd.test.ts`, `e2e/exec.test.ts`, `e2e/repros/issue-1527.test.ts`.
 
 ### How to build one
 
-1. Start from an existing e2e test file and copy the style.
-2. Keep the scenario deterministic:
-   - prefer asserting concrete behavior (`found` vs `missing`, explicit versions, exact command output).
-   - avoid shell-specific probes when a small Node script can validate behavior uniformly.
-3. Use the shell matrix unless the behavior is explicitly shell-specific.
-4. Keep setup minimal and local to the test (write only files required for the scenario).
-5. Name tests by behavior, and for repros include the issue id in the test name.
+1. Copy an existing e2e test style.
+2. Keep assertions deterministic (`found`/`missing`, explicit versions, exact outputs).
+3. Prefer shell-agnostic checks (often a small Node script) over shell-specific probing.
+4. Use shell matrix unless behavior is explicitly shell-specific.
+5. Keep setup local/minimal and include issue id in repro test names.
 
 ### Example scenarios to copy
 
@@ -51,27 +35,6 @@ They are used for user-facing behavior that unit tests cannot fully cover (for e
 - Cross-shell behavior checks: `e2e/use-on-cd.test.ts`
 - Feature flags via env: `e2e/corepack.test.ts` (`shell.env({ corepackEnabled: true })`)
 - Repro that verifies state before and after a command: `e2e/repros/issue-1527.test.ts`
-
-### Minimal template
-
-```ts
-import { script } from "./shellcode/script.js"
-import { Bash, Fish, PowerShell, WinCmd, Zsh } from "./shellcode/shells.js"
-import describe from "./describe.js"
-
-for (const shell of [Bash, Zsh, Fish, PowerShell, WinCmd]) {
-  describe(shell, () => {
-    test("my behavior", async () => {
-      await script(shell)
-        .then(shell.env({}))
-        .then(shell.call("fnm", ["install", "18"]))
-        .then(shell.call("fnm", ["use", "18"]))
-        .then(shell.scriptOutputContains(shell.call("node", ["-v"]), "v18"))
-        .execute(shell)
-    })
-  })
-}
-```
 
 ### Running tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,42 +1,34 @@
 # fnm (fast node manager)
 
+this project is focused on optimizations. the fact it is written in Rust is NOT the reason it's performant.
+"what we do" and "what we do not do" are the main reasons for fnm's performance. we have a very specific scope and we have to do it well.
+
+use tools like `hyperfine` to measure performance.
+add end to end tests to avoid regressions and to prove that features actually work.
+
 ## End-to-end tests
 
-### What they do
+E2E tests validate real-shell user behavior (`fnm env`, `fnm use`, PATH updates, global binaries, cross-version workflows).
 
-E2E tests validate user-facing fnm behavior inside real shells (`fnm env`, `fnm use`, PATH updates, global binaries, cross-version workflows).
+- Tests: `e2e/*.test.ts`; repros: `e2e/repros/*.test.ts`.
+- Use shell matrix with `describe(shell, () => { ... })` unless behavior is shell-specific.
+- Build scripts with `script(shell)` and use `shell.env({...})`, `shell.call(...)`, `shell.scriptOutputContains(...)`, `shell.hasCommandOutput(...)`.
+- Keep assertions deterministic (`found`/`missing`, explicit versions, exact outputs); prefer shell-agnostic checks.
+- Write JavaScript code to disk and evaluate with Node.js if you need complex assertions as they are more maintainable than shell scripts.
+- Keep setup local/minimal and include issue id in repro test names.
+- Mirror is `FNM_NODE_DIST_MIRROR=http://localhost:8080`; avoid unrelated network dependencies.
 
-### How they work
-
-- Tests live in `e2e/*.test.ts`; issue repros in `e2e/repros/*.test.ts`.
-- Most tests run a shell matrix via `describe(shell, () => { ... })`.
-- `script(shell)` builds and runs a shell script in isolated temp dirs.
-- Use `shell.env({...})`, `shell.call(...)`, `shell.scriptOutputContains(...)`, and `shell.hasCommandOutput(...)`.
-- Harness uses `FNM_NODE_DIST_MIRROR=http://localhost:8080`; avoid unrelated network dependencies.
-
-### Where to look
-
-- Core interfaces: `e2e/shellcode/script.ts`, `e2e/shellcode/shells.ts`, `e2e/shellcode/shells/types.ts`.
-- Assertions/helpers: `e2e/shellcode/shells/output-contains.ts`, `e2e/shellcode/shells/expect-command-output.ts`, `e2e/shellcode/shells/cmdCall.ts`.
+- Interfaces: `e2e/shellcode/script.ts`, `e2e/shellcode/shells.ts`, `e2e/shellcode/shells/types.ts`.
+- Helpers: `e2e/shellcode/shells/output-contains.ts`, `e2e/shellcode/shells/expect-command-output.ts`, `e2e/shellcode/shells/cmdCall.ts`.
 - Shell coverage behavior: `e2e/describe.ts`.
-- Example tests: `e2e/basic.test.ts`, `e2e/use-on-cd.test.ts`, `e2e/exec.test.ts`, `e2e/repros/issue-1527.test.ts`.
+- Examples: `e2e/basic.test.ts`, `e2e/use-on-cd.test.ts`, `e2e/exec.test.ts`, `e2e/corepack.test.ts`, `e2e/repros/issue-1527.test.ts`.
 
-### How to build one
+- Run one file: `pnpm test -- e2e/repros/issue-1527.test.ts`
+- Run all e2e: `pnpm test -- e2e`
 
-1. Copy an existing e2e test style.
-2. Keep assertions deterministic (`found`/`missing`, explicit versions, exact outputs).
-3. Prefer shell-agnostic checks (often a small Node script) over shell-specific probing.
-4. Use shell matrix unless behavior is explicitly shell-specific.
-5. Keep setup local/minimal and include issue id in repro test names.
+## Features, Bugfixes and Changes
 
-### Example scenarios to copy
-
-- Version resolution from files: `e2e/basic.test.ts` (`.nvmrc`, `.node-version`, `package.json` engines)
-- Cross-shell behavior checks: `e2e/use-on-cd.test.ts`
-- Feature flags via env: `e2e/corepack.test.ts` (`shell.env({ corepackEnabled: true })`)
-- Repro that verifies state before and after a command: `e2e/repros/issue-1527.test.ts`
-
-### Running tests
-
-- Single file: `pnpm test -- e2e/repros/issue-1527.test.ts`
-- Full e2e suite: `pnpm test -- e2e`
+Every code change requires a changeset in <repo_root>/.changeset/some-random-name.md
+We should avoid breaking changes. Therefore 99.9% of changesets should be "patch" or "minor".
+Be concise and clear in the changeset title, and provide examples or links to related issues if necessary.
+See ./.changeset/EXAMPLE.md for an example of a changeset format.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,79 @@
+# fnm (fast node manager)
+
+## End-to-end tests
+
+### What they do
+
+E2E tests validate fnm behavior inside real shells, including shell integration, PATH updates, and cross-version workflows.
+They are used for user-facing behavior that unit tests cannot fully cover (for example: `fnm env`, `fnm use`, global package visibility, and shell-specific behavior).
+
+### How they work
+
+- E2E tests live under `e2e/*.test.ts` and repro cases can live under `e2e/repros/*.test.ts`.
+- Tests are usually run in a shell matrix (commonly `Bash`, `Zsh`, `Fish`, `PowerShell`, `WinCmd`) via `describe(shell, () => { ... })`.
+- `script(shell)` builds a shell script step-by-step and executes it in an isolated temp directory.
+- `shell.env({...})` injects fnm shell setup and feature flags.
+- `shell.call("cmd", ["arg1", "arg2"])` appends command lines to the script.
+- `shell.scriptOutputContains(...)` and `shell.hasCommandOutput(...)` are the main assertion helpers.
+- The harness sets `FNM_NODE_DIST_MIRROR=http://localhost:8080` (proxy-backed), so tests should rely on existing mirrored behavior and avoid introducing unrelated network dependencies.
+
+### Where to look
+
+- Interface entrypoints:
+  - `e2e/shellcode/script.ts` (`script(shell)`, execution model, env wiring)
+  - `e2e/shellcode/shells.ts` (shell matrix definitions and capabilities)
+  - `e2e/shellcode/shells/types.ts` (shared shell/script interfaces)
+- Assertion helpers:
+  - `e2e/shellcode/shells/output-contains.ts` (`shell.scriptOutputContains`)
+  - `e2e/shellcode/shells/expect-command-output.ts` (`shell.hasCommandOutput`)
+  - `e2e/shellcode/shells/cmdCall.ts` (`shell.call` command construction)
+- Shell coverage behavior:
+  - `e2e/describe.ts` (shell-specific `describe`, WinCmd skip behavior)
+- Concrete test examples:
+  - `e2e/basic.test.ts` (core install/use/version assertions)
+  - `e2e/use-on-cd.test.ts` (directory-driven switching)
+  - `e2e/exec.test.ts` (`fnm exec` scenarios)
+  - `e2e/repros/issue-1527.test.ts` (issue repro pattern)
+
+### How to build one
+
+1. Start from an existing e2e test file and copy the style.
+2. Keep the scenario deterministic:
+   - prefer asserting concrete behavior (`found` vs `missing`, explicit versions, exact command output).
+   - avoid shell-specific probes when a small Node script can validate behavior uniformly.
+3. Use the shell matrix unless the behavior is explicitly shell-specific.
+4. Keep setup minimal and local to the test (write only files required for the scenario).
+5. Name tests by behavior, and for repros include the issue id in the test name.
+
+### Example scenarios to copy
+
+- Version resolution from files: `e2e/basic.test.ts` (`.nvmrc`, `.node-version`, `package.json` engines)
+- Cross-shell behavior checks: `e2e/use-on-cd.test.ts`
+- Feature flags via env: `e2e/corepack.test.ts` (`shell.env({ corepackEnabled: true })`)
+- Repro that verifies state before and after a command: `e2e/repros/issue-1527.test.ts`
+
+### Minimal template
+
+```ts
+import { script } from "./shellcode/script.js"
+import { Bash, Fish, PowerShell, WinCmd, Zsh } from "./shellcode/shells.js"
+import describe from "./describe.js"
+
+for (const shell of [Bash, Zsh, Fish, PowerShell, WinCmd]) {
+  describe(shell, () => {
+    test("my behavior", async () => {
+      await script(shell)
+        .then(shell.env({}))
+        .then(shell.call("fnm", ["install", "18"]))
+        .then(shell.call("fnm", ["use", "18"]))
+        .then(shell.scriptOutputContains(shell.call("node", ["-v"]), "v18"))
+        .execute(shell)
+    })
+  })
+}
+```
+
+### Running tests
+
+- Single file: `pnpm test -- e2e/repros/issue-1527.test.ts`
+- Full e2e suite: `pnpm test -- e2e`


### PR DESCRIPTION
## Summary
- add `AGENTS.md` guidance focused on performance mindset and practical e2e testing conventions
- include concrete pointers to e2e interfaces, helpers, examples, and test commands
- add changeset guidance and include `.changeset/EXAMPLE.md` plus a changeset for this docs update