### PR TITLE
feat: add possible values to the arch help docs.

### DIFF
--- a/.changeset/witty-pans-crash.md
+++ b/.changeset/witty-pans-crash.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+feat: add possible values to the arch help docs.

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -1,6 +1,7 @@
 use crate::version::Version;
+use clap::ValueEnum;
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, ValueEnum)]
 pub enum Arch {
     X86,
     X64,


### PR DESCRIPTION
Adds the possible values that can be used with the `--arch` flag in the help docs.

## before

```sh
      --arch <ARCH>
          Override the architecture of the installed Node binary. Defaults to arch of fnm binary
          
          [env: FNM_ARCH]
```

## after

```sh
      --arch <ARCH>
          Override the architecture of the installed Node binary. Defaults to arch of fnm binary
          
          [env: FNM_ARCH]
          [possible values: x86, x64, x64-musl, x64-glibc217, arm64, armv7l, ppc64le, ppc64, s390x]
```