### PR TITLE
PowerShell `--use-on-cd` enhancements

### DIFF
--- a/src/shell/powershell.rs
+++ b/src/shell/powershell.rs
@@ -42,10 +42,12 @@ impl Shell for PowerShell {
         };
         Ok(formatdoc!(
             r"
-                $global:cd_before_fnm = (Get-Command 'cd' -ErrorAction Ignore)
-                if (-not $global:cd_before_fnm) {{ $global:cd_before_fnm = 'Set-Location' }}
                 function global:Set-FnmOnLoad {{ {autoload_hook} }}
-                function global:Set-LocationWithFnm {{ & $global:cd_before_fnm @args; Set-FnmOnLoad }}
+                & {{
+                    $cd = (Get-Command 'cd' -ErrorAction Ignore)
+                    if (-not $cd) {{ $cd = 'Set-Location' }}
+                    Set-Item Function:\global:Set-LocationWithFnm {{ & $cd @args; Set-FnmOnLoad }}.GetNewClosure()
+                }}
                 Set-Alias -Scope global cd_with_fnm Set-LocationWithFnm
                 Set-Alias -Option AllScope -Scope global cd Set-LocationWithFnm
             ",

--- a/src/shell/powershell.rs
+++ b/src/shell/powershell.rs
@@ -45,7 +45,7 @@ impl Shell for PowerShell {
                 $global:cd_before_fnm = (Get-Command 'cd' -ErrorAction Ignore)
                 if (-not $global:cd_before_fnm) {{ $global:cd_before_fnm = 'Set-Location' }}
                 function global:Set-FnmOnLoad {{ {autoload_hook} }}
-                function global:Set-LocationWithFnm {{ param($path); if ($path -eq $null) {{ & $global:cd_before_fnm }} else {{ & $global:cd_before_fnm $path }}; Set-FnmOnLoad }}
+                function global:Set-LocationWithFnm {{ & $global:cd_before_fnm @args; Set-FnmOnLoad }}
                 Set-Alias -Scope global cd_with_fnm Set-LocationWithFnm
                 Set-Alias -Option AllScope -Scope global cd Set-LocationWithFnm
             ",

--- a/src/shell/powershell.rs
+++ b/src/shell/powershell.rs
@@ -42,8 +42,10 @@ impl Shell for PowerShell {
         };
         Ok(formatdoc!(
             r"
+                $global:cd_before_fnm = (Get-Command 'cd' -ErrorAction Ignore)
+                if (-not $global:cd_before_fnm) {{ $global:cd_before_fnm = 'Set-Location' }}
                 function global:Set-FnmOnLoad {{ {autoload_hook} }}
-                function global:Set-LocationWithFnm {{ param($path); if ($path -eq $null) {{Set-Location}} else {{Set-Location $path}}; Set-FnmOnLoad }}
+                function global:Set-LocationWithFnm {{ param($path); if ($path -eq $null) {{ & $global:cd_before_fnm }} else {{ & $global:cd_before_fnm $path }}; Set-FnmOnLoad }}
                 Set-Alias -Scope global cd_with_fnm Set-LocationWithFnm
                 Set-Alias -Option AllScope -Scope global cd Set-LocationWithFnm
             ",


### PR DESCRIPTION
This PR includes the following changes for the `fnm env --use-on-cd` script emitted for PowerShell:
- The `cd` command applicable when the `fnm env` script is sourced is invoked by the emitted function, instead of `Set-Location` directly. Fixes #1350.
- All params of the emitted `cd` function are forwarded to the underlying `cd` function using [splatting](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_splatting?view=powershell-7.5#splatting-command-parameters).

## Demo

With the following PowerShell profile,

```powershell
# customCd prints its args to cd before continuing with Set-Location.
function customCd { Write-Host "customCd: [$args]" ; Set-Location @args }
Set-Alias -Option AllScope -Scope Global 'cd' 'customCd'

fnm env --shell powershell --use-on-cd | Out-String | Invoke-Expression
```

<img width="500" src="https://github.com/user-attachments/assets/a8cfcc39-ca11-482a-822f-096bdbffaf4b" />

Notice how, on PowerShell 5 & 7,
- `cd`-ing uses FNM on cd, and delegates to the `customCd` function.
- Parameters of the underlying `cd` function (in this case the `-PassThru` option of `Set-Location`) can be specified.