### PR TITLE
fix: fetch remote version file when using certs

### DIFF
--- a/.changeset/certs-fix.md
+++ b/.changeset/certs-fix.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+Fix fnm being unable to fetch remote versions files when TLS certs are configured on the system.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ description = "Fast and simple Node.js version manager"
 serde = { version = "1.0.203", features = ["derive"] }
 clap = { version = "4.5.4", features = ["derive", "env"] }
 serde_json = "1.0.117"
-chrono = { version = "0.4.38", features = ["serde", "now"], default-features = false }
+chrono = { version = "0.4.38", features = ["serde", "now"] }
 tar = "0.4.40"
 xz2 = "0.1.7"
 node-semver = "2.1.0"


### PR DESCRIPTION
Fix for being unable to fetch the remote version file when using TLS certificates.  When `default-features` is set to false `reqwest` is unable to obtain the CA configuration and it results in failed requests. 

Fixes #1432