### PR TITLE
feat: forward FNM_AUTH_HEADER as Authorization on dist mirror requests

### DIFF
--- a/.changeset/auth-header-mirror-support.md
+++ b/.changeset/auth-header-mirror-support.md
@@ -1,0 +1,10 @@
+---
+"fnm": minor
+---
+
+Add `FNM_AUTH_HEADER` env variable. When set, its value is forwarded verbatim as the `Authorization` HTTP header on requests to the Node.js dist mirror, enabling fnm to work with private/auth-protected mirrors.
+
+```sh-session
+$ export FNM_AUTH_HEADER="Bearer ghp_xxxxxxxxxxxx"
+$ fnm install 22
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,3 +70,16 @@ Then:
 
 - `fnm install` will install the latest satisfying Node.js 20.x version available in the Node.js dist server
 - `fnm use` will use the latest satisfying Node.js 20.x version available on your system, or prompt to install if no version matched.
+
+## Environment variables
+
+### `FNM_AUTH_HEADER`
+
+When set, the value is sent verbatim as the `Authorization` HTTP header on every request fnm makes to the Node.js dist mirror. Use this with private or authenticated mirrors.
+
+```sh
+export FNM_AUTH_HEADER="Bearer ghp_xxxxxxxxxxxxxxxx"
+fnm install 22
+```
+
+The value is forwarded as-is, so you control the auth scheme (`Bearer …`, `Basic …`, or any other token format your mirror expects). Set it in your shell profile or CI secret store — avoid echoing or committing it.

--- a/e2e/auth-header.test.ts
+++ b/e2e/auth-header.test.ts
@@ -1,0 +1,28 @@
+import { script } from "./shellcode/script.js"
+import { Bash } from "./shellcode/shells.js"
+import describe from "./describe.js"
+
+describe(Bash, () => {
+  test(`forwards FNM_AUTH_HEADER as Authorization on dist mirror requests`, async () => {
+    await script(Bash)
+      .addExtraEnvVar("FNM_AUTH_HEADER", "Bearer test-token-xyz")
+      .then(Bash.env({}))
+      .then(Bash.call("fnm", ["ls-remote"]))
+      .execute(Bash)
+
+    const res = await fetch("http://localhost:8080/__last_auth")
+    const { authorization } = (await res.json()) as { authorization: string | null }
+    expect(authorization).toBe("Bearer test-token-xyz")
+  })
+
+  test(`sends no Authorization header when FNM_AUTH_HEADER is unset`, async () => {
+    await script(Bash)
+      .then(Bash.env({}))
+      .then(Bash.call("fnm", ["ls-remote"]))
+      .execute(Bash)
+
+    const res = await fetch("http://localhost:8080/__last_auth")
+    const { authorization } = (await res.json()) as { authorization: string | null }
+    expect(authorization).toBeNull()
+  })
+})

--- a/e2e/shellcode/script.ts
+++ b/e2e/shellcode/script.ts
@@ -19,7 +19,7 @@ class Script {
     private readonly extraEnvVars: Record<string, string> = {}
   ) {}
   then(line: ScriptLine): Script {
-    return new Script(this.config, [...this.lines, line])
+    return new Script(this.config, [...this.lines, line], this.extraEnvVars)
   }
 
   takeSnapshot(shell: Pick<Shell, "name">): this {

--- a/src/archive/zip.rs
+++ b/src/archive/zip.rs
@@ -86,8 +86,11 @@ mod tests {
     #[test_log::test]
     fn test_zip_extraction() {
         let temp_dir = &tempfile::tempdir().expect("Can't create a temp directory");
-        let response = crate::http::get("https://nodejs.org/dist/v12.0.0/node-v12.0.0-win-x64.zip")
-            .expect("Can't make request to Node v12.0.0 zip file");
+        let response = crate::http::get(
+            "https://nodejs.org/dist/v12.0.0/node-v12.0.0-win-x64.zip",
+            None,
+        )
+        .expect("Can't make request to Node v12.0.0 zip file");
         Box::new(Zip::new(response))
             .extract_into(temp_dir.as_ref())
             .expect("Can't unzip files");

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -94,7 +94,7 @@ impl Command for Env {
         let multishell_path = make_symlink(config)?;
         let base_dir = config.base_dir_with_default();
 
-        let env_vars = [
+        let mut env_vars = vec![
             ("FNM_MULTISHELL_PATH", multishell_path.to_str().unwrap()),
             (
                 "FNM_VERSION_FILE_STRATEGY",
@@ -111,11 +111,13 @@ impl Command for Env {
             ("FNM_ARCH", config.arch.as_str()),
         ];
 
+        if let Some(auth) = config.auth_header().filter(|s| !s.is_empty()) {
+            env_vars.push(("FNM_AUTH_HEADER", auth));
+        }
+
         if self.json {
-            println!(
-                "{}",
-                serde_json::to_string(&HashMap::from(env_vars)).unwrap()
-            );
+            let json_map: HashMap<_, _> = env_vars.iter().copied().collect();
+            println!("{}", serde_json::to_string(&json_map).unwrap());
             return Ok(());
         }
 

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -85,8 +85,9 @@ impl Command for Install {
                 return Err(Error::UninstallableVersion { version: v });
             }
             UserVersion::Full(Version::Lts(lts_type)) => {
-                let available_versions: Vec<_> = remote_node_index::list(&config.node_dist_mirror)
-                    .map_err(|source| Error::CantListRemoteVersions { source })?;
+                let available_versions: Vec<_> =
+                    remote_node_index::list(&config.node_dist_mirror, config.auth_header())
+                        .map_err(|source| Error::CantListRemoteVersions { source })?;
                 let picked_version = lts_type
                     .pick_latest(&available_versions)
                     .ok_or_else(|| Error::CantFindRelevantLts {
@@ -102,8 +103,9 @@ impl Command for Install {
                 picked_version
             }
             UserVersion::Full(Version::Latest) => {
-                let available_versions: Vec<_> = remote_node_index::list(&config.node_dist_mirror)
-                    .map_err(|source| Error::CantListRemoteVersions { source })?;
+                let available_versions: Vec<_> =
+                    remote_node_index::list(&config.node_dist_mirror, config.auth_header())
+                        .map_err(|source| Error::CantListRemoteVersions { source })?;
                 let picked_version = available_versions
                     .last()
                     .ok_or(Error::CantFindLatest)?
@@ -117,11 +119,12 @@ impl Command for Install {
                 picked_version
             }
             current_version => {
-                let available_versions: Vec<_> = remote_node_index::list(&config.node_dist_mirror)
-                    .map_err(|source| Error::CantListRemoteVersions { source })?
-                    .drain(..)
-                    .map(|x| x.version)
-                    .collect();
+                let available_versions: Vec<_> =
+                    remote_node_index::list(&config.node_dist_mirror, config.auth_header())
+                        .map_err(|source| Error::CantListRemoteVersions { source })?
+                        .drain(..)
+                        .map(|x| x.version)
+                        .collect();
 
                 current_version
                     .to_version(&available_versions, config)
@@ -150,6 +153,7 @@ impl Command for Install {
             config.installations_dir(),
             safe_arch,
             show_progress,
+            config.auth_header(),
         ) {
             Err(err @ DownloaderError::VersionAlreadyInstalled { .. }) => {
                 outln!(config, Error, "{} {}", "warning:".bold().yellow(), err);
@@ -308,7 +312,8 @@ mod tests {
         .expect("Can't install");
 
         let available_versions: Vec<_> =
-            remote_node_index::list(&config.node_dist_mirror).expect("Can't get node version list");
+            remote_node_index::list(&config.node_dist_mirror, config.auth_header())
+                .expect("Can't get node version list");
         let latest_version = available_versions.last().unwrap().version.clone();
 
         assert!(config.installations_dir().exists());

--- a/src/commands/ls_remote.rs
+++ b/src/commands/ls_remote.rs
@@ -51,7 +51,8 @@ impl super::command::Command for LsRemote {
     type Error = Error;
 
     fn apply(self, config: &FnmConfig) -> Result<(), Self::Error> {
-        let mut all_versions = remote_node_index::list(&config.node_dist_mirror)?;
+        let mut all_versions =
+            remote_node_index::list(&config.node_dist_mirror, config.auth_header())?;
 
         if let Some(lts) = &self.lts {
             match lts {

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,17 @@ pub struct FnmConfig {
     #[clap(long, env = "FNM_MULTISHELL_PATH", hide_env_values = true, hide = true)]
     multishell_path: Option<std::path::PathBuf>,
 
+    /// Value sent verbatim as the `Authorization` header on requests to the
+    /// Node.js dist mirror. Use this for authenticated/private mirrors.
+    #[clap(
+        long,
+        env = "FNM_AUTH_HEADER",
+        global = true,
+        hide_env_values = true,
+        hide = true
+    )]
+    auth_header: Option<String>,
+
     /// The log level of fnm commands
     #[clap(
         long,
@@ -106,6 +117,7 @@ impl Default for FnmConfig {
             node_dist_mirror: Url::parse("https://nodejs.org/dist/").unwrap(),
             base_dir: None,
             multishell_path: None,
+            auth_header: None,
             log_level: LogLevel::Info,
             arch: Arch::default(),
             version_file_strategy: VersionFileStrategy::default(),
@@ -134,6 +146,10 @@ impl FnmConfig {
             None => None,
             Some(v) => Some(v.as_path()),
         }
+    }
+
+    pub fn auth_header(&self) -> Option<&str> {
+        self.auth_header.as_deref()
     }
 
     pub fn log_level(&self) -> LogLevel {

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -73,6 +73,7 @@ pub fn install_node_dist<P: AsRef<Path>>(
     installations_dir: P,
     arch: Arch,
     show_progress: bool,
+    auth_header: Option<&str>,
 ) -> Result<(), Error> {
     let installation_dir = PathBuf::from(installations_dir.as_ref()).join(version.v_str());
 
@@ -93,7 +94,7 @@ pub fn install_node_dist<P: AsRef<Path>>(
         let ext = extract.file_extension();
         let url = download_url(node_dist_mirror, version, arch, ext);
         debug!("Going to call for {}", &url);
-        let response = crate::http::get(url.as_str())?;
+        let response = crate::http::get(url.as_str(), auth_header)?;
 
         if !response.status().is_success() {
             continue;
@@ -175,7 +176,7 @@ mod tests {
         let version = Version::parse("12.0.0").unwrap();
         let arch = Arch::X64;
         let node_dist_mirror = Url::parse("https://nodejs.org/dist/").unwrap();
-        install_node_dist(&version, &node_dist_mirror, path, arch, false)
+        install_node_dist(&version, &node_dist_mirror, path, arch, false, None)
             .expect("Can't install Node 12");
 
         let mut location_path = path.join(version.v_str()).join("installation");

--- a/src/http.rs
+++ b/src/http.rs
@@ -10,10 +10,15 @@ use reqwest::{blocking::Client, IntoUrl};
 pub struct Error(#[from] reqwest::Error);
 pub type Response = reqwest::blocking::Response;
 
-pub fn get(url: impl IntoUrl) -> Result<Response, Error> {
-    Ok(Client::new()
+pub fn get(url: impl IntoUrl, auth_header: Option<&str>) -> Result<Response, Error> {
+    let mut req = Client::new()
         .get(url)
         // Some sites require a user agent.
-        .header("User-Agent", concat!("fnm ", env!("CARGO_PKG_VERSION")))
-        .send()?)
+        .header("User-Agent", concat!("fnm ", env!("CARGO_PKG_VERSION")));
+
+    if let Some(auth) = auth_header.filter(|s| !s.is_empty()) {
+        req = req.header(reqwest::header::AUTHORIZATION, auth);
+    }
+
+    Ok(req.send()?)
 }

--- a/src/remote_node_index.rs
+++ b/src/remote_node_index.rs
@@ -81,10 +81,10 @@ pub enum Error {
 /// ```rust
 /// use crate::remote_node_index::list;
 /// ```
-pub fn list(base_url: &Url) -> Result<Vec<IndexedNodeVersion>, Error> {
+pub fn list(base_url: &Url, auth_header: Option<&str>) -> Result<Vec<IndexedNodeVersion>, Error> {
     let base_url = base_url.as_str().trim_end_matches('/');
     let index_json_url = format!("{base_url}/index.json");
-    let resp = crate::http::get(&index_json_url)?
+    let resp = crate::http::get(&index_json_url, auth_header)?
         .error_for_status()
         .map_err(crate::http::Error::from)?;
     let text = resp.text().map_err(crate::http::Error::from)?;
@@ -103,7 +103,7 @@ mod tests {
     fn test_list() {
         let base_url = Url::parse("https://nodejs.org/dist").unwrap();
         let expected_version = Version::parse("12.0.0").unwrap();
-        let mut versions = list(&base_url).expect("Can't get HTTP data");
+        let mut versions = list(&base_url, None).expect("Can't get HTTP data");
         assert_eq!(
             versions
                 .drain(..)

--- a/tests/proxy-server/index.mjs
+++ b/tests/proxy-server/index.mjs
@@ -16,6 +16,9 @@ try {
 /** @type {Map<string, Promise<{ headers: Record<string, string>, body: ArrayBuffer }>>} */
 const cache = new Map()
 
+/** @type {string | null} */
+let lastAuth = null
+
 /**
  * @param {object} opts
  * @param {string} opts.pathname
@@ -39,6 +42,15 @@ const download = async ({ pathname, filename, headersFilename }) => {
 
 export const server = createServer((req, res) => {
   const pathname = req.url ?? "/"
+
+  if (pathname === "/__last_auth") {
+    res.writeHead(200, { "content-type": "application/json" })
+    res.end(JSON.stringify({ authorization: lastAuth }))
+    return
+  }
+
+  lastAuth = req.headers["authorization"] ?? null
+
   const hash = crypto
     .createHash("sha1")
     .update(pathname ?? "/")


### PR DESCRIPTION
## Summary

- Add `FNM_AUTH_HEADER` env variable. When set, its value is sent verbatim as the `Authorization` HTTP header on every request fnm makes to the Node.js dist mirror — enabling fnm to work against private / auth-protected mirrors.
- Value is forwarded as-is so the user controls the auth scheme (`Bearer …`, `Basic …`, custom).
- New field on `FnmConfig` is hidden from `--help` to discourage passing tokens via CLI args (where they leak into `ps` / shell history); set the env var instead.
- `fnm env` re-exports `FNM_AUTH_HEADER` when set so subshells inherit it (consistent with the other `FNM_*` vars).

## Implementation

- `src/config.rs` — new `auth_header: Option<String>` field (clap `env = "FNM_AUTH_HEADER"`, `hide = true`, `hide_env_values = true`) plus `auth_header()` getter.
- `src/http.rs` — `get()` accepts `Option<&str>` and attaches `reqwest::header::AUTHORIZATION` when non-empty.
- `src/downloader.rs`, `src/remote_node_index.rs` — threaded through to `http::get`.
- `src/commands/install.rs`, `src/commands/ls_remote.rs` — pass `config.auth_header()`.
- `src/commands/env.rs` — conditionally re-export `FNM_AUTH_HEADER` from `fnm env`.
- `tests/proxy-server/index.mjs` — capture last-seen Authorization, expose `GET /__last_auth` sentinel for e2e assertion.
- `e2e/auth-header.test.ts` — Bash-only positive + negative tests.
- `e2e/shellcode/script.ts` — fix latent bug where `then()` dropped `extraEnvVars` (surfaced by the new test).
- `docs/configuration.md` — document the env var.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test --bin fnm` (30/30 pass)
- [x] `pnpm test -- e2e/auth-header.test.ts` (2/2 pass)
- [x] `pnpm test -- e2e/env.test.ts` — no regression on the existing `fnm env --json` snapshot
- [x] Manual smoke: `FNM_AUTH_HEADER="Bearer xyz" fnm ls-remote` against a proxy confirms the wire-level `Authorization` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)