### PR TITLE
Windows Installer Script

### DIFF
--- a/.ci/install.cmd
+++ b/.ci/install.cmd
@@ -105,10 +105,18 @@ if not exist %userprofile%\profile.cmd (
     echo We have just created this file for you
 )
 
+:: This sets the **USER** path to include ~/.local/bin *persistent* across sessions
+powershell "$current = (Get-ItemProperty -Path 'HKCU:\Environment' -Name Path).Path; if (-not $current.Contains($env:userprofile + '\.local\bin')) { [Environment]::SetEnvironmentVariable('Path', $current + ';' + $env:userprofile + '\.local\bin;', 'User') }"
+
+:: We still need to do this for the *current* session, though.
+:: The above only takes affect from the next new...
+set path=%PATH%;%userprofile%\.local\bin
+
+
 echo Adding FNM section to %userprofile%\profile.cmd
 
 echo. >> %userprofile%\profile.cmd
-echo :: FNM
+echo :: FNM >> %userprofile%\profile.cmd
 echo :: for /F will launch a new instance of cmd so we create a guard to prevent an infnite loop >> %userprofile%\profile.cmd
 echo if not defined FNM_AUTORUN_GUARD ( >> %userprofile%\profile.cmd
 echo     set "FNM_AUTORUN_GUARD=AutorunGuard" >> %userprofile%\profile.cmd
@@ -120,9 +128,6 @@ echo Setting up powershell
 :: There's no downside to "force creating" a directory, it does nothing if it already exists...
 powershell New-Item -Type Directory "$((Get-Item $PROFILE).Directory.FullName)" -Force 2>&1>NUL
 powershell Add-Content -Path $PROFILE -Value '', '# FNM', 'fnm env --use-on-cd --shell powershell ^| Out-String ^| Invoke-Expression' -Encoding UTF8
-
-:: Lazy...
-set path=%PATH%;%userprofile%\.local\bin
 
 exit /b
 

--- a/.ci/install.cmd
+++ b/.ci/install.cmd
@@ -1,0 +1,139 @@
+@echo off
+
+setlocal enabledelayedexpansion
+
+set INSTALL_DIR=%userprofile%\.local\bin
+set SKIP_SHELL=false
+set RELEASE=latest
+
+:parse_args
+if "%1"=="" goto :main
+if "%1"=="-d" (
+    set INSTALL_DIR=%2
+    shift 
+    shift 
+) 
+if "%1"=="--install-dir" (
+    set INSTALL_DIR=%2
+    shift 
+    shift 
+    goto :parse_args
+) 
+if "%1"=="-s" (
+    set SKIP_SHELL=true
+    shift 
+    goto :parse_args
+) 
+if "%1"=="--skip-shell" (
+    set SKIP_SHELL=true
+    shift 
+    goto :parse_args
+) 
+if "%1"=="-r" (
+    set RELEASE=%2
+    shift 
+    shift 
+    goto :parse_args
+) 
+if "%1"=="--release" (
+    set RELEASE=%2
+    shift 
+    shift 
+    goto :parse_args
+) 
+echo Unrecognised argument: `%1`
+goto :eof
+
+:check_dependencies
+echo Checking dependencies for the installation script...
+
+echo Checking availability of curl...
+where curl 2>&1> NUL
+if %errorlevel%==0 (
+    echo OK!
+) else (
+    echo Missing!
+    set SHOULD_EXIT=true
+)
+
+echo Checking availability of powershell...
+where powershell 2>&1> NUL
+if %errorlevel%==0 (
+    echo OK!
+) else (
+    echo Missing!
+    set SHOULD_EXIT=true
+)
+
+if "%SHOULD_EXIT%"=="true" (
+    echo Not installing fnm due to missing dependencies.
+    goto :eof
+) 
+exit /b
+
+:download_fnm
+if "%RELEASE%"=="latest" (
+    set URL="https://github.com/Schniz/fnm/releases/latest/download/fnm-windows.zip"
+) else (
+    set URL="https://github.com/Schniz/fnm/releases/download/%RELEASE%/fnm-windows.zip"
+)
+echo Downloading %URL%
+
+if not exist %INSTALL_DIR% mkdir %INSTALL_DIR%
+
+curl --progress-bar --fail -L "%URL%" -o "%temp%\fnm-windows.zip"
+if not %errorlevel%==0 (
+    echo Download failed.  Check that the release/filename are correct.
+    goto :eof
+)
+
+echo Extracting zip from %temp%\fnm-windows.zip
+powershell Expand-Archive -Path "$env:temp\fnm-windows.zip" -DestinationPath "$env:temp" -Force
+if exist %temp%\fnm.exe (
+    move "%temp%\fnm.exe" "%INSTALL_DIR%" 2>&1>NUL
+) else (
+    move "%temp%\fnm-windows\fnm.exe" "%INSTALL_DIR%" 2>&1>NUL
+)
+exit /b
+
+:setup_shells
+echo Adding %userprofile%\profile.cmd as startup script for cmd
+reg add "HKCU\Software\Microsoft\Command Processor" /v Autorun /d "call %userprofile%\profile.cmd" /f 
+
+if not exist %userprofile%\profile.cmd (
+    echo @echo off > %userprofile%\profile.cmd
+    echo We have just created this file for you
+)
+
+echo Adding FNM section to %userprofile%\profile.cmd
+
+echo. >> %userprofile%\profile.cmd
+echo :: FNM
+echo :: for /F will launch a new instance of cmd so we create a guard to prevent an infnite loop >> %userprofile%\profile.cmd
+echo if not defined FNM_AUTORUN_GUARD ( >> %userprofile%\profile.cmd
+echo     set "FNM_AUTORUN_GUARD=AutorunGuard" >> %userprofile%\profile.cmd
+echo     FOR /f "tokens=*" %%z IN ('fnm env --use-on-cd') DO CALL %%z >> %userprofile%\profile.cmd
+echo ) >> %userprofile%\profile.cmd
+
+echo Setting up powershell
+
+:: There's no downside to "force creating" a directory, it does nothing if it already exists...
+powershell New-Item -Type Directory "$((Get-Item $PROFILE).Directory.FullName)" -Force 2>&1>NUL
+powershell Add-Content -Path $PROFILE -Value '', '# FNM', 'fnm env --use-on-cd --shell powershell ^| Out-String ^| Invoke-Expression' -Encoding UTF8
+
+:: Lazy...
+set path=%PATH%;%userprofile%\.local\bin
+
+exit /b
+
+:main
+echo Install dir: %INSTALL_DIR%
+echo Skip Shell : %SKIP_SHELL%
+echo Release    : %RELEASE%
+call :check_dependencies
+call :download_fnm
+if not "%SKIP_SHELL%"=="true" (
+    call :setup_shells
+)
+
+goto :eof

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ First ensure that `curl` and `unzip` are already installed on your operating sys
 curl -fsSL https://fnm.vercel.app/install | bash
 ```
 
+### Using a script (Windows)
+
+If you are running >= Windows 10, curl is pre-installed and PowerShell 5 has
+`Expand-Archive` cmdlet.
+
+```cmd
+curl -fsSLO https://fnm.vercel.app/install.cmd && install.cmd
+```
+
 #### Upgrade
 
 On macOS, it is as simple as `brew upgrade fnm`.


### PR DESCRIPTION
Hiya. 

First want to start this off by saying thanks for being a sane project that doesn't require admin permissions to do things you can easily do without!!! 

I know you already list a number of ways to install for Windows, but I see a few people with issues either WinGet being funky, PowerShell requiring Admin access to Set-ExecutionPolicy etc.

In effort of making it so we don't have to elevate, here is a cmd (dos) script that is compatible with any Windows device Windows 10 + (or any Windows device with curl.exe in path and PowerShell with Expand-Archive cmdlet).

Sorry if the .ci folder isn't the right place, you link to it in the README so I figured next to it would be sensible. In the README I put the cmd extension to the typical vercel install link you give as an example (rather than pointing to my own repo...).

I've copied from your original install.sh, stripping out parts not relevant as this is a Windows specific script (you only distribute a single zip for windows so simplified a decent chunk of the script) 

Really appreciate you taking the time to read through this and review, if you have any questions or issues let me know!

Thanks!!