### PR TITLE
Don't pass duplicate /d flag in Windows cmd use-on-cd hook

### DIFF
--- a/.changeset/witty-drives-turn.md
+++ b/.changeset/witty-drives-turn.md
@@ -1,0 +1,10 @@
+---
+"fnm": patch
+---
+
+fix `cd /d <drive>` failing in Windows Command Prompt when use-on-cd is enabled: the generated `cd.cmd` always prepended `/d`, so a user-supplied `/d` was passed twice and `cd` failed with "The syntax of the command is incorrect". Fixes #1556
+
+```sh-session
+> cd /d D:\
+The syntax of the command is incorrect.
+```

--- a/e2e/repros/issue-1556.test.ts
+++ b/e2e/repros/issue-1556.test.ts
@@ -1,0 +1,22 @@
+import { writeFile, mkdir } from "node:fs/promises"
+import { join } from "node:path"
+import { script } from "../shellcode/script.js"
+import { WinCmd } from "../shellcode/shells.js"
+import testCwd from "../shellcode/test-cwd.js"
+import testNodeVersion from "../shellcode/test-node-version.js"
+import describe from "../describe.js"
+
+describe(WinCmd, () => {
+  test(`issue #1556: cd /d works with use-on-cd`, async () => {
+    const subdir = join(testCwd(), "subdir")
+    await mkdir(subdir, { recursive: true })
+    await writeFile(join(subdir, ".node-version"), "v12.22.12")
+    await script(WinCmd)
+      .then(WinCmd.env({ useOnCd: true }))
+      .then(WinCmd.call("fnm", ["install", "v8.11.3"]))
+      .then(WinCmd.call("fnm", ["install", "v12.22.12"]))
+      .then(WinCmd.call("cd", ["/d", subdir]))
+      .then(testNodeVersion(WinCmd, "v12.22.12"))
+      .execute(WinCmd)
+  })
+})

--- a/src/shell/windows_cmd/cd.cmd
+++ b/src/shell/windows_cmd/cd.cmd
@@ -1,5 +1,9 @@
 @echo off
-cd /d %*
+rem Add /d only when the user didn't pass it themselves, so `cd /d D:\` works (#1556).
+rem No if/else parentheses or setlocal here: %* may contain ")" (e.g. "C:\Program Files (x86)"),
+rem and endlocal would revert the directory change.
+if /i "%~1" == "/d" cd %*
+if /i not "%~1" == "/d" cd /d %*
 if "%FNM_VERSION_FILE_STRATEGY%" == "recursive" (
   fnm use --silent-if-unchanged
 ) else (


### PR DESCRIPTION
Fixes #1556

## Problem

The generated `cd.cmd` always runs `cd /d %*`. When the user supplies their own `/d` (e.g. `cd /d D:\`), the flag is passed twice and cmd fails with:

```
The syntax of the command is incorrect.
```

## Fix

Add `/d` only when the first argument isn't already `/d`:

```cmd
if /i "%~1" == "/d" cd %*
if /i not "%~1" == "/d" cd /d %*
```

The shape is deliberate — each alternative fails in a non-obvious way (all verified empirically on Windows 11 cmd.exe):

- **No parenthesized `if/else` blocks**: `%*` may contain `)` — `cd /d C:\Program Files (x86)` inside a `( ... )` block closes the block early and breaks the command. The current single-line form handles it; a block would regress it.
- **No `setlocal`**: `endlocal` reverts directory changes, which would break `cd` entirely.
- **No `goto`/labels**: the file is stored with LF endings and embedded byte-exact via `include_bytes!`; cmd's label scanning is unreliable with LF-only line endings. The two guarded ifs avoid labels altogether.
- **First-argument check only** (rather than scanning all args): native `cd` itself only accepts `/d` before the path (`cd C:\ /d` fails with "The system cannot find the path specified"), so positions after the first never work anyway and are passed through to native `cd` to produce its normal error.

## Testing

WinCmd e2e tests are currently skip-listed (`e2e/describe.ts`), so I verified the behavior directly on Windows 11 with a 15-case matrix against real `cmd.exe`, comparing old script vs new script vs native `cd`:

| Case | Old | New |
|---|---|---|
| `cd /d Y:\` (cross-drive via `subst`, dir contains `.node-version`) | ❌ syntax error | ✅ cd works + `fnm use --silent-if-unchanged` fires |
| `cd /D Y:\` (uppercase) | ❌ | ✅ |
| `cd ..`, `cd \`, `cd` (no args) | ✅ | ✅ unchanged |
| `cd "C:\Program Files"` / unquoted `cd C:\Program Files` | ✅ | ✅ unchanged |
| `cd C:\Program Files (x86)` and `cd /d C:\Program Files (x86)` | ✅ / ❌ | ✅ / ✅ |
| nonexistent dir | stays put + native error | unchanged |
| `.node-version` / `.nvmrc` / `FNM_VERSION_FILE_STRATEGY=recursive` triggers | ✅ | ✅ unchanged (verified with a stubbed `fnm` on PATH) |
| environment variable leakage into the session | none | none (fix uses no variables) |

Also verified:

- The LF-endings variant of the script (what release binaries embed) passes the same cases.
- `cargo test` — 28/28 pass, including `shell::windows_cmd::tests::use_on_cd_quotes_macro_path`.
- Built `fnm.exe env --use-on-cd --shell cmd` generates the fixed script; re-ran key cases against the generated file.
- Added `e2e/repros/issue-1556.test.ts` per AGENTS.md (WinCmd-only; it self-skips today but will cover this once WinCmd e2e is enabled). Compiles under jest, prettier clean.
- Changeset included (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5TQ1y3yBEDx73tYTHoUBj