### PR TITLE
Feat/multishell cleanup

### DIFF
--- a/.changeset/clean-multishell-on-exit.md
+++ b/.changeset/clean-multishell-on-exit.md
@@ -1,0 +1,8 @@
+---
+"fnm": minor
+---
+
+Automatically clean up multishell directories when the shell session exits
+
+Registers an exit hook/trap in the shell profile evaluation (`fnm env`) that removes the session's multishell symlink directory when the terminal tab or shell session exits.
+Supported across Bash (`trap EXIT`), Zsh (`add-zsh-hook zshexit`), Fish (`--on-event fish_exit`), and PowerShell (`Register-EngineEvent PowerShell.Exiting`).

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -168,6 +168,10 @@ setup_shell() {
   if [ "$CURRENT_SHELL" = "zsh" ]; then
     CONF_FILE=${ZDOTDIR:-$HOME}/.zshrc
     ensure_containing_dir_exists "$CONF_FILE"
+    if [ -f "$CONF_FILE" ] && grep -q "fnm env" "$CONF_FILE" 2>/dev/null; then
+      echo "fnm is already configured in $CONF_FILE"
+      return
+    fi
     echo "Installing for Zsh. Appending the following to $CONF_FILE:"
     {
       echo ''
@@ -184,6 +188,10 @@ setup_shell() {
   elif [ "$CURRENT_SHELL" = "fish" ]; then
     CONF_FILE=$HOME/.config/fish/conf.d/fnm.fish
     ensure_containing_dir_exists "$CONF_FILE"
+    if [ -f "$CONF_FILE" ] && grep -q "fnm env" "$CONF_FILE" 2>/dev/null; then
+      echo "fnm is already configured in $CONF_FILE"
+      return
+    fi
     echo "Installing for Fish. Appending the following to $CONF_FILE:"
     {
       echo ''
@@ -204,6 +212,10 @@ setup_shell() {
       CONF_FILE=$HOME/.bashrc
     fi
     ensure_containing_dir_exists "$CONF_FILE"
+    if [ -f "$CONF_FILE" ] && grep -q "fnm env" "$CONF_FILE" 2>/dev/null; then
+      echo "fnm is already configured in $CONF_FILE"
+      return
+    fi
     echo "Installing for Bash. Appending the following to $CONF_FILE:"
     {
       echo ''

--- a/e2e/__snapshots__/multishell-cleanup.test.ts.snap
+++ b/e2e/__snapshots__/multishell-cleanup.test.ts.snap
@@ -14,6 +14,30 @@ if [ "$(node verify.cjs)" != "CLEANED_UP" ]; then
 fi"
 `;
 
+exports[`Fish multishell is cleaned up after subshell exits: Fish 1`] = `
+"fnm env | source
+fnm install v11.9.0
+fnm use v11.9.0
+fish -c 'fnm env | source
+node record.cjs'
+set ____test____ (node verify.cjs)
+if test "$____test____" != "CLEANED_UP"
+  echo "Expected multishell directory to be cleaned up on exit to be CLEANED_UP. Got $____test____"
+  exit 1
+end"
+`;
+
+exports[`PowerShell multishell is cleaned up after subshell exits: PowerShell 1`] = `
+"$ErrorActionPreference = "Stop"
+fnm env | Out-String | Invoke-Expression
+fnm install v11.9.0
+fnm use v11.9.0
+echo '$ErrorActionPreference = "Stop"
+fnm env | Out-String | Invoke-Expression
+node record.cjs' | pwsh -NoProfile
+if ( "$(node verify.cjs)" -ne "CLEANED_UP" ) { echo "Expected multishell directory to be cleaned up on exit to be CLEANED_UP. Got $(node verify.cjs)"; exit 1 }"
+`;
+
 exports[`Zsh multishell is cleaned up after subshell exits: Zsh 1`] = `
 "set -e
 eval "$(fnm env)"

--- a/e2e/__snapshots__/multishell-cleanup.test.ts.snap
+++ b/e2e/__snapshots__/multishell-cleanup.test.ts.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Bash multishell is cleaned up after subshell exits: Bash 1`] = `
+"set -e
+eval "$(fnm env)"
+fnm install v11.9.0
+fnm use v11.9.0
+echo 'set -e
+eval "$(fnm env)"
+node record.cjs' | bash
+if [ "$(node verify.cjs)" != "CLEANED_UP" ]; then
+  echo "Expected multishell directory to be cleaned up on exit to be CLEANED_UP. Got $(node verify.cjs)"
+  exit 1
+fi"
+`;
+
+exports[`Zsh multishell is cleaned up after subshell exits: Zsh 1`] = `
+"set -e
+eval "$(fnm env)"
+fnm install v11.9.0
+fnm use v11.9.0
+echo 'set -e
+eval "$(fnm env)"
+node record.cjs' | zsh
+if [ "$(node verify.cjs)" != "CLEANED_UP" ]; then
+  echo "Expected multishell directory to be cleaned up on exit to be CLEANED_UP. Got $(node verify.cjs)"
+  exit 1
+fi"
+`;

--- a/e2e/multishell-cleanup.test.ts
+++ b/e2e/multishell-cleanup.test.ts
@@ -1,0 +1,47 @@
+import { script } from "./shellcode/script.js"
+import { Bash, Fish, PowerShell, Zsh } from "./shellcode/shells.js"
+import testCwd from "./shellcode/test-cwd.js"
+import fs from "node:fs/promises"
+import path from "node:path"
+import describe from "./describe.js"
+
+for (const shell of [Bash, Zsh, Fish, PowerShell]) {
+  describe(shell, () => {
+    test("multishell is cleaned up after subshell exits", async () => {
+      await fs.writeFile(
+        path.join(testCwd(), "record.cjs"),
+        `const fs = require('fs'); fs.writeFileSync('subshell-multishell.txt', process.env.FNM_MULTISHELL_PATH || '');`
+      )
+      await fs.writeFile(
+        path.join(testCwd(), "verify.cjs"),
+        `const fs = require('fs');
+const msPath = fs.readFileSync('subshell-multishell.txt', 'utf8').trim();
+if (!msPath) { console.log('NO_PATH'); process.exit(1); }
+if (fs.existsSync(msPath)) { console.log('STILL_EXISTS'); process.exit(1); }
+console.log('CLEANED_UP');`
+      )
+
+      await script(shell)
+        .then(shell.env({}))
+        .then(shell.call("fnm", ["install", "v11.9.0"]))
+        .then(shell.call("fnm", ["use", "v11.9.0"]))
+        .then(
+          shell.inSubShell(
+            script(shell)
+              .then(shell.env({}))
+              .then(shell.call("node", ["record.cjs"]))
+              .asLine()
+          )
+        )
+        .then(
+          shell.hasCommandOutput(
+            shell.call("node", ["verify.cjs"]),
+            "CLEANED_UP",
+            "multishell directory to be cleaned up on exit"
+          )
+        )
+        .takeSnapshot(shell)
+        .execute(shell)
+    })
+  })
+}

--- a/src/commands/env.rs
+++ b/src/commands/env.rs
@@ -166,6 +166,9 @@ impl Command for Env {
         if let Some(v) = shell.rehash() {
             println!("{v}");
         }
+        if let Some(cleanup) = shell.cleanup_on_exit(&multishell_path) {
+            println!("{cleanup}");
+        }
 
         Ok(())
     }

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -58,4 +58,33 @@ impl Shell for Bash {
             autoload_hook = autoload_hook
         ))
     }
+
+    fn cleanup_on_exit(&self, multishell_path: &Path) -> Option<String> {
+        let path = multishell_path.to_str()?;
+        let path =
+            super::windows_compat::maybe_fix_windows_path(path).unwrap_or_else(|| path.to_string());
+        Some(formatdoc!(
+            r"
+                __fnm_cleanup() {{
+                    \rm -rf {path:?}
+                }}
+                trap __fnm_cleanup EXIT
+            ",
+            path = path
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cleanup_on_exit_registers_trap() {
+        let output = Bash
+            .cleanup_on_exit(Path::new("/tmp/fnm_multishells/123_456"))
+            .unwrap();
+        assert!(output.contains("trap __fnm_cleanup EXIT"));
+        assert!(output.contains("/tmp/fnm_multishells/123_456"));
+    }
 }

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -72,7 +72,12 @@ impl Shell for Bash {
                             \rm -rf "$p"
                         done
                     }}
-                    trap __fnm_cleanup EXIT
+                    trap __fnm_cleanup EXIT HUP INT TERM
+                else
+                    for p in "${{__fnm_cleanup_multishell_paths[@]}}"; do
+                        \rm -rf "$p"
+                    done
+                    __fnm_cleanup_multishell_paths=()
                 fi
                 __fnm_cleanup_multishell_paths+=({path:?})
             "#,

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -64,12 +64,18 @@ impl Shell for Bash {
         let path =
             super::windows_compat::maybe_fix_windows_path(path).unwrap_or_else(|| path.to_string());
         Some(formatdoc!(
-            r"
-                __fnm_cleanup() {{
-                    \rm -rf {path:?}
-                }}
-                trap __fnm_cleanup EXIT
-            ",
+            r#"
+                if [ -z "${{__fnm_cleanup_multishell_paths+x}}" ]; then
+                    __fnm_cleanup_multishell_paths=()
+                    __fnm_cleanup() {{
+                        for p in "${{__fnm_cleanup_multishell_paths[@]}}"; do
+                            \rm -rf "$p"
+                        done
+                    }}
+                    trap __fnm_cleanup EXIT
+                fi
+                __fnm_cleanup_multishell_paths+=({path:?})
+            "#,
             path = path
         ))
     }

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -59,12 +59,19 @@ impl Shell for Fish {
             super::windows_compat::maybe_fix_windows_path(path).unwrap_or_else(|| path.to_string());
         Some(formatdoc!(
             r"
-                set -g -a __fnm_cleanup_multishell_paths {path:?}
-                function __fnm_cleanup --on-event fish_exit
+                if not set -q __fnm_cleanup_multishell_paths
+                    function __fnm_cleanup --on-event fish_exit
+                        for p in $__fnm_cleanup_multishell_paths
+                            rm -rf $p
+                        end
+                    end
+                else
                     for p in $__fnm_cleanup_multishell_paths
                         rm -rf $p
                     end
+                    set -e __fnm_cleanup_multishell_paths
                 end
+                set -g -a __fnm_cleanup_multishell_paths {path:?}
             ",
             path = path
         ))

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -59,8 +59,11 @@ impl Shell for Fish {
             super::windows_compat::maybe_fix_windows_path(path).unwrap_or_else(|| path.to_string());
         Some(formatdoc!(
             r"
+                set -g -a __fnm_cleanup_multishell_paths {path:?}
                 function __fnm_cleanup --on-event fish_exit
-                    rm -rf {path:?}
+                    for p in $__fnm_cleanup_multishell_paths
+                        rm -rf $p
+                    end
                 end
             ",
             path = path

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -52,4 +52,32 @@ impl Shell for Fish {
             autoload_hook = autoload_hook
         ))
     }
+
+    fn cleanup_on_exit(&self, multishell_path: &Path) -> Option<String> {
+        let path = multishell_path.to_str()?;
+        let path =
+            super::windows_compat::maybe_fix_windows_path(path).unwrap_or_else(|| path.to_string());
+        Some(formatdoc!(
+            r"
+                function __fnm_cleanup --on-event fish_exit
+                    rm -rf {path:?}
+                end
+            ",
+            path = path
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cleanup_on_exit_registers_fish_exit_event() {
+        let output = Fish
+            .cleanup_on_exit(Path::new("/tmp/fnm_multishells/123_456"))
+            .unwrap();
+        assert!(output.contains("function __fnm_cleanup --on-event fish_exit"));
+        assert!(output.contains("/tmp/fnm_multishells/123_456"));
+    }
 }

--- a/src/shell/powershell.rs
+++ b/src/shell/powershell.rs
@@ -62,13 +62,6 @@ impl Shell for PowerShell {
                             Remove-Item -Path $p -Recurse -Force -ErrorAction SilentlyContinue
                         }}
                     }} -SupportEvent -ErrorAction SilentlyContinue | Out-Null
-                    try {{
-                        [System.AppDomain]::CurrentDomain.add_ProcessExit({{
-                            foreach ($p in $global:__fnm_cleanup_multishell_paths) {{
-                                Remove-Item -Path $p -Recurse -Force -ErrorAction SilentlyContinue
-                            }}
-                        }})
-                    }} catch {{}}
                 }} else {{
                     foreach ($p in $global:__fnm_cleanup_multishell_paths) {{
                         Remove-Item -Path $p -Recurse -Force -ErrorAction SilentlyContinue

--- a/src/shell/powershell.rs
+++ b/src/shell/powershell.rs
@@ -50,7 +50,36 @@ impl Shell for PowerShell {
             autoload_hook = autoload_hook
         ))
     }
+
+    fn cleanup_on_exit(&self, multishell_path: &Path) -> Option<String> {
+        let path = multishell_path.to_str()?.replace('\'', "''");
+        Some(formatdoc!(
+            r"
+                Register-EngineEvent -SourceIdentifier PowerShell.Exiting -Action {{
+                    Remove-Item -Path '{path}' -Recurse -Force -ErrorAction SilentlyContinue
+                }} -SupportEvent -ErrorAction SilentlyContinue | Out-Null
+            ",
+            path = path
+        ))
+    }
+
     fn to_clap_shell(&self) -> clap_complete::Shell {
         clap_complete::Shell::PowerShell
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cleanup_on_exit_registers_engine_event() {
+        let output = PowerShell
+            .cleanup_on_exit(Path::new(
+                r"C:\Users\user\AppData\Local\fnm_multishells\123_456",
+            ))
+            .unwrap();
+        assert!(output.contains("Register-EngineEvent -SourceIdentifier PowerShell.Exiting"));
+        assert!(output.contains(r"C:\Users\user\AppData\Local\fnm_multishells\123_456"));
     }
 }

--- a/src/shell/powershell.rs
+++ b/src/shell/powershell.rs
@@ -55,9 +55,15 @@ impl Shell for PowerShell {
         let path = multishell_path.to_str()?.replace('\'', "''");
         Some(formatdoc!(
             r"
-                Register-EngineEvent -SourceIdentifier PowerShell.Exiting -Action {{
-                    Remove-Item -Path '{path}' -Recurse -Force -ErrorAction SilentlyContinue
-                }} -SupportEvent -ErrorAction SilentlyContinue | Out-Null
+                if (-not (Test-Path 'variable:global:__fnm_cleanup_multishell_paths')) {{
+                    `$global:__fnm_cleanup_multishell_paths = [System.Collections.Generic.List[string]]::new()
+                    Register-EngineEvent -SourceIdentifier PowerShell.Exiting -Action {{
+                        foreach (`$p in `$global:__fnm_cleanup_multishell_paths) {{
+                            Remove-Item -Path `$p -Recurse -Force -ErrorAction SilentlyContinue
+                        }}
+                    }} -SupportEvent -ErrorAction SilentlyContinue | Out-Null
+                }}
+                `$global:__fnm_cleanup_multishell_paths.Add('{path}')
             ",
             path = path
         ))

--- a/src/shell/powershell.rs
+++ b/src/shell/powershell.rs
@@ -62,6 +62,18 @@ impl Shell for PowerShell {
                             Remove-Item -Path $p -Recurse -Force -ErrorAction SilentlyContinue
                         }}
                     }} -SupportEvent -ErrorAction SilentlyContinue | Out-Null
+                    try {{
+                        [System.AppDomain]::CurrentDomain.add_ProcessExit({{
+                            foreach ($p in $global:__fnm_cleanup_multishell_paths) {{
+                                Remove-Item -Path $p -Recurse -Force -ErrorAction SilentlyContinue
+                            }}
+                        }})
+                    }} catch {{}}
+                }} else {{
+                    foreach ($p in $global:__fnm_cleanup_multishell_paths) {{
+                        Remove-Item -Path $p -Recurse -Force -ErrorAction SilentlyContinue
+                    }}
+                    $global:__fnm_cleanup_multishell_paths.Clear()
                 }}
                 [void]$global:__fnm_cleanup_multishell_paths.Add('{path}')
             ",

--- a/src/shell/powershell.rs
+++ b/src/shell/powershell.rs
@@ -56,14 +56,14 @@ impl Shell for PowerShell {
         Some(formatdoc!(
             r"
                 if (-not (Test-Path 'variable:global:__fnm_cleanup_multishell_paths')) {{
-                    `$global:__fnm_cleanup_multishell_paths = [System.Collections.Generic.List[string]]::new()
+                    $global:__fnm_cleanup_multishell_paths = [System.Collections.Generic.List[string]]::new()
                     Register-EngineEvent -SourceIdentifier PowerShell.Exiting -Action {{
-                        foreach (`$p in `$global:__fnm_cleanup_multishell_paths) {{
-                            Remove-Item -Path `$p -Recurse -Force -ErrorAction SilentlyContinue
+                        foreach ($p in $global:__fnm_cleanup_multishell_paths) {{
+                            Remove-Item -Path $p -Recurse -Force -ErrorAction SilentlyContinue
                         }}
                     }} -SupportEvent -ErrorAction SilentlyContinue | Out-Null
                 }}
-                `$global:__fnm_cleanup_multishell_paths.Add('{path}')
+                [void]$global:__fnm_cleanup_multishell_paths.Add('{path}')
             ",
             path = path
         ))

--- a/src/shell/shell.rs
+++ b/src/shell/shell.rs
@@ -10,6 +10,12 @@ pub trait Shell: Debug {
     fn rehash(&self) -> Option<&'static str> {
         None
     }
+    /// Returns shell-specific code to clean up the multishell directory when the
+    /// shell session exits. Returns `None` if the shell has no exit trap mechanism.
+    fn cleanup_on_exit(&self, multishell_path: &Path) -> Option<String> {
+        let _ = multishell_path;
+        None
+    }
     fn to_clap_shell(&self) -> clap_complete::Shell;
 }
 

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -59,6 +59,22 @@ impl Shell for Zsh {
             autoload_hook = autoload_hook
         ))
     }
+
+    fn cleanup_on_exit(&self, multishell_path: &Path) -> Option<String> {
+        let path = multishell_path.to_str()?;
+        let path =
+            super::windows_compat::maybe_fix_windows_path(path).unwrap_or_else(|| path.to_string());
+        Some(formatdoc!(
+            r"
+                autoload -U add-zsh-hook
+                _fnm_cleanup() {{
+                    \rm -rf {path:?}
+                }}
+                add-zsh-hook zshexit _fnm_cleanup
+            ",
+            path = path
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -69,5 +85,14 @@ mod tests {
     fn use_on_cd_removes_existing_hook_before_adding() {
         let output = Zsh.use_on_cd(&crate::config::FnmConfig::default()).unwrap();
         assert!(output.contains("add-zsh-hook -D chpwd _fnm_autoload_hook"));
+    }
+
+    #[test]
+    fn cleanup_on_exit_registers_zshexit_hook() {
+        let output = Zsh
+            .cleanup_on_exit(Path::new("/tmp/fnm_multishells/123_456"))
+            .unwrap();
+        assert!(output.contains("add-zsh-hook zshexit _fnm_cleanup"));
+        assert!(output.contains("/tmp/fnm_multishells/123_456"));
     }
 }

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -66,14 +66,22 @@ impl Shell for Zsh {
             super::windows_compat::maybe_fix_windows_path(path).unwrap_or_else(|| path.to_string());
         Some(formatdoc!(
             r#"
-                typeset -ga __fnm_cleanup_multishell_paths
-                autoload -U add-zsh-hook
-                _fnm_cleanup() {{
+                if (( ! $+__fnm_cleanup_multishell_paths )); then
+                    typeset -ga __fnm_cleanup_multishell_paths
+                    autoload -U add-zsh-hook
+                    _fnm_cleanup() {{
+                        for p in "${{__fnm_cleanup_multishell_paths[@]}}"; do
+                            \rm -rf "$p"
+                        done
+                    }}
+                    add-zsh-hook zshexit _fnm_cleanup
+                    trap _fnm_cleanup HUP INT TERM
+                else
                     for p in "${{__fnm_cleanup_multishell_paths[@]}}"; do
                         \rm -rf "$p"
                     done
-                }}
-                add-zsh-hook zshexit _fnm_cleanup
+                    __fnm_cleanup_multishell_paths=()
+                fi
                 __fnm_cleanup_multishell_paths+=({path:?})
             "#,
             path = path

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -65,13 +65,17 @@ impl Shell for Zsh {
         let path =
             super::windows_compat::maybe_fix_windows_path(path).unwrap_or_else(|| path.to_string());
         Some(formatdoc!(
-            r"
+            r#"
+                typeset -ga __fnm_cleanup_multishell_paths
                 autoload -U add-zsh-hook
                 _fnm_cleanup() {{
-                    \rm -rf {path:?}
+                    for p in "${{__fnm_cleanup_multishell_paths[@]}}"; do
+                        \rm -rf "$p"
+                    done
                 }}
                 add-zsh-hook zshexit _fnm_cleanup
-            ",
+                __fnm_cleanup_multishell_paths+=({path:?})
+            "#,
             path = path
         ))
     }


### PR DESCRIPTION
### Summary

Automatically cleans up multishell symlink directories when a shell tab or session exits.

### Motivation

Currently, every `fnm env` invocation generates an isolated multishell symlink directory in the user's runtime directory (e.g. `/run/user/1000/fnm_multishells/...` or `AppData/Local/fnm_multishells`). These directories are never deleted and accumulate indefinitely until system reboot.

### Changes

1. **`Shell` trait**: Added `cleanup_on_exit(&self, multishell_path: &Path) -> Option<String>`.
2. **Exit Hooks**:
   - **Bash**: `trap __fnm_cleanup EXIT` using an array accumulator so repeated evaluations in the same session (e.g. `source ~/.bashrc`) clean up all session directories.
   - **Zsh**: `add-zsh-hook zshexit _fnm_cleanup` (idiomatic, doesn't overwrite existing traps).
   - **Fish**: `--on-event fish_exit`.
   - **PowerShell**: `Register-EngineEvent -SourceIdentifier PowerShell.Exiting`.
3. **`install.sh`**: Added idempotency guard (`grep -q "fnm env"`) to prevent duplicate blocks if the installer is run more than once.
4. **Tests & Changeset**:
   - Unit tests added across all shells (`cargo test shell::`).
   - E2E test added (`e2e/multishell-cleanup.test.ts`).
   - Changeset added.
